### PR TITLE
Add an "env" property, which allows passing environment variables.

### DIFF
--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -355,7 +355,15 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
 
     seed = random.getrandbits(63)
     env = process_handling.mark_environment(os.environ)
+    # Copy any env=NAME1=VALUE:NAME2=VALUE into the environment
+    # We do this first so that it can't overwrite anything below.
+    if 'env' in properties:
+        env_settings = [x.split('=', 1) for x in properties['env'].split(':')]
+        for k, v in env_settings:
+          env[k] = v
     for k, v in properties.items():
+        if k == 'env':
+            continue
         env["JOSHUA_" + k.upper()] = str(v)
     env["JOSHUA_SEED"] = str(seed).rstrip("L")
     # process_handling.ensure_path(env)


### PR DESCRIPTION
I have a use case where it'd be convenient to be able to specify different parameters for the code under test without having to rebuild the joshua package for each new configuration.  This PR introduces a meaning to the "env" property, which is colon separated (character being an arbitrary choice) list of environment variables to set before invoking the test.

As an example, adding `--property=env=FOO=BAR:BAR=BAZ` to a `joshua start` invocation means that `joshua_test` will see `$FOO` as "BAR" and `$BAR` as "BAZ".

I ran this code though a some quick tests locally, but didn't embark on the fight of setting up a local joshua for this simple of a change.