### PR TITLE
Upgrade python36 to python38, ruby24 to ruby27

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,21 +3,23 @@ FROM centos:centos7
 # Install Python 3 and Mono
 RUN yum update all && yum install -y yum-utils && \
     yum -y install centos-release-scl epel-release && \
-    yum -y install gcc mono-core rh-python36-python rh-python36-python-devel \
-           rh-python36-python-pip valgrind net-tools golang java-11-openjdk \
-           sysvinit-tools rh-ruby24 rh-ruby24-ruby-devel make \
+    yum -y install gcc mono-core rh-python38-python rh-python38-python-devel \
+           rh-python38-python-pip valgrind net-tools golang java-11-openjdk \
+           sysvinit-tools rh-ruby27 rh-ruby27-ruby-devel make \
            libasan libubsan && \
-    scl enable rh-python36 -- pip install python-dateutil subprocess32 psutil && \
-    scl enable rh-ruby24 -- gem install ffi --platform=ruby
+    scl enable rh-python38 -- pip install python-dateutil subprocess32 psutil && \
+    scl enable rh-ruby27 -- gem install ffi --platform=ruby
 
 # Install Joshua python package and fix time zone
 ARG TIMEZONEINFO=America/Los_Angeles
 ADD install /opt/joshua/install
-RUN scl enable rh-python36 -- pip install /opt/joshua/install && rm -rf /opt/joshua/install && rm -f /etc/localtime && ln -s /usr/share/zoneinfo/${TIMEZONEINFO} /etc/localtime
+RUN scl enable rh-python38 -- pip install /opt/joshua/install && rm -rf /opt/joshua/install && rm -f /etc/localtime && ln -s /usr/share/zoneinfo/${TIMEZONEINFO} /etc/localtime
 
-# Download and install old fdbserver binaries, TLS libraries, and C bindings.
+# Download and install old fdbserver binaries, TLS libraries, and C bindings. (x86_64 build only)
 COPY download_old_fdb.sh start_agents.py /usr/bin/
-RUN /usr/bin/download_old_fdb.sh 1
+RUN if [ "$(uname -p)" == "x86_64" ]; then \
+        /usr/bin/download_old_fdb.sh 1; \
+    fi
 
 # Add the user and group joshua
 RUN groupadd -r joshua -g 4060 && useradd -rm -d /home/joshua -s /bin/bash -u 4060 -g joshua joshua && mkdir -p /var/joshua && chown -R joshua:joshua /var/joshua
@@ -62,4 +64,4 @@ LABEL version=${DOCKER_IMAGEVER}
 # Run the image as joshua
 USER joshua
 
-CMD scl enable rh-python36 rh-ruby24 -- python3 -u /usr/bin/start_agents.py -C "${CLUSTER_FILE}" --dir "${AGENT_WORK_DIR}" --name-space "${AGENT_NAMESPACE}" --number "${AGENT_TOTAL}" --priority "${AGENT_PRIORITY}" --free-cpus "${AGENT_FREECPUS}" --free-space "${AGENT_FREESPACE}" --growth-rate "${AGENT_GROWTHRATE}" --report-freq "${AGENT_REPORTFREQ}" --mgr-sleep "${AGENT_MGRSLEEP}"
+CMD scl enable rh-python38 rh-ruby27 -- python3 -u /usr/bin/start_agents.py -C "${CLUSTER_FILE}" --dir "${AGENT_WORK_DIR}" --name-space "${AGENT_NAMESPACE}" --number "${AGENT_TOTAL}" --priority "${AGENT_PRIORITY}" --free-cpus "${AGENT_FREECPUS}" --free-space "${AGENT_FREESPACE}" --growth-rate "${AGENT_GROWTHRATE}" --report-freq "${AGENT_REPORTFREQ}" --mgr-sleep "${AGENT_MGRSLEEP}"

--- a/k8s/agent-scaler/Dockerfile
+++ b/k8s/agent-scaler/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:centos7
 # Install Python 3 and Mono
 RUN yum update all && yum install -y yum-utils && \
     yum -y install centos-release-scl epel-release && \
-    yum -y install rh-python36-python rh-python36-python-pip gettext
+    yum -y install rh-python38-python rh-python38-python-pip gettext
 
 # kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /bin/
@@ -19,7 +19,7 @@ RUN chmod +x /lib64/libfdb_c.so
 ENV LD_LIBRARY_PATH="/lib64:$LD_LIBRARY_PATH"
 
 # FDB python binding
-RUN scl enable rh-python36 -- pip install foundationdb
+RUN scl enable rh-python38 -- pip install foundationdb
 
 ENV BATCH_SIZE=1
 ENV MAX_JOBS=10

--- a/k8s/joshua-agent/Dockerfile
+++ b/k8s/joshua-agent/Dockerfile
@@ -13,4 +13,4 @@ ENV AGENT_TIMEOUT=300
 
 # start 1 agent only
 # --work_dir and --cluster-file must be specified via command line
-CMD scl enable rh-python36 rh-ruby24 -- python3 -m joshua.joshua_agent -C ${FDB_CLUSTER_FILE} --work_dir ${AGENT_WORK_DIR} --agent-idle-timeout ${AGENT_TIMEOUT}
+CMD scl enable rh-python38 rh-ruby27 -- python3 -m joshua.joshua_agent -C ${FDB_CLUSTER_FILE} --work_dir ${AGENT_WORK_DIR} --agent-idle-timeout ${AGENT_TIMEOUT}


### PR DESCRIPTION
Upgrade python36 to python38, and ruby24 to ruby27 in order to support aarch64 platform.
CentOS7 on aarch64 does not provide python36 and ruby24.
Also, skip download_old_fdb.sh on non-x86_64 platforms as prebuilt binaries are not available for those platforms.