### PR TITLE
Fix a bug where 'env' property is empty

### DIFF
--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -529,7 +529,8 @@ if __name__ == "__main__":
         metavar='name=value',
         dest='env',
         action='append',
-        default=[])
+        default=[],
+        help="environment variable to add to the job's execution")
     parser_start.set_defaults(cmd=start_ensemble)
 
     parser_stop = subparsers.add_parser('stop', help='stop a test ensemble')

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -114,6 +114,7 @@ def start_ensemble(tarball,
                    max_runs=100000,
                    no_max_runs=False,
                    priority=100,
+                   env=[],
                    printable=True,
                    **args):
     if not allow_multiple:
@@ -123,6 +124,7 @@ def start_ensemble(tarball,
     properties['compressed'] = compressed
     properties['sanity'] = sanity
     properties['priority'] = priority
+    properties['env'] = ':'.join(env)
 
     if not no_timeout:
         properties['timeout'] = timeout
@@ -522,6 +524,12 @@ if __name__ == "__main__":
         metavar='PRIORITY',
         default=100,
         help='percent adjustment of CPU time allocated to this job')
+    parser_start.add_argument(
+        '--env',
+        metavar='name=value',
+        dest='env',
+        action='append',
+        default=[])
     parser_start.set_defaults(cmd=start_ensemble)
 
     parser_stop = subparsers.add_parser('stop', help='stop a test ensemble')

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -124,7 +124,9 @@ def start_ensemble(tarball,
     properties['compressed'] = compressed
     properties['sanity'] = sanity
     properties['priority'] = priority
-    properties['env'] = ':'.join(env)
+    if env:
+        # omit 'env' property if nothing is set
+        properties['env'] = ':'.join(env)
 
     if not no_timeout:
         properties['timeout'] = timeout

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -357,7 +357,7 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
     env = process_handling.mark_environment(os.environ)
     # Copy any env=NAME1=VALUE:NAME2=VALUE into the environment
     # We do this first so that it can't overwrite anything below.
-    if 'env' in properties:
+    if 'env' in properties and properties['env']:
         env_settings = [x.split('=', 1) for x in properties['env'].split(':')]
         for k, v in env_settings:
           env[k] = v

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -355,7 +355,15 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
 
     seed = random.getrandbits(63)
     env = process_handling.mark_environment(os.environ)
+    # Copy any env=NAME1=VALUE:NAME2=VALUE into the environment
+    # We do this first so that it can't overwrite anything below.
+    if 'env' in properties:
+        env_settings = [x.split('=', 1) for x in properties['env'].split(':')]
+        for k, v in env_settings:
+          env[k] = v
     for k, v in properties.items():
+        if k == 'env':
+            continue
         env["JOSHUA_" + k.upper()] = str(v)
     env["JOSHUA_SEED"] = str(seed).rstrip("L")
     # process_handling.ensure_path(env)


### PR DESCRIPTION
Because the property is empty, agent will crash when trying to unpack the
property.

This fixes the crash reported in #10. Oleg reported that this fixed the crash https://github.com/FoundationDB/fdb-joshua/issues/10#issuecomment-816755153