### PR TITLE
Optionally take FDB_VERSION from shell

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,14 +4,21 @@ set -Eeuo pipefail
 RUN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 COMMIT_HASH=$(git rev-parse --short=10  HEAD)
 DATE_STR=$(date +"%Y%m%d%H%M%S")
-FDB_VERSION=$(curl -Ls https://www.foundationdb.org/downloads/version.txt)
+
+# avoid unbound variable
+FDB_VERSION=${FDB_VERSION:-}
+if [ ! -z ${FDB_VERSION} ]; then
+  fdb_version_arg="--build-arg FDB_VERSION=${FDB_VERSION}"
+else
+  fdb_version_arg=""
+fi
 
 ################################################################################
 # joshua-agent
 ################################################################################
 docker build \
   --build-arg REPOSITORY=foundationdb/build \
-  --build-arg FDB_VERSION="${FDB_VERSION}" \
+  ${fdb_version_arg} \
   --tag foundationdb/joshua-agent:"${DATE_STR}-${COMMIT_HASH}" \
   --tag foundationdb/joshua-agent:latest \
   .
@@ -22,7 +29,7 @@ cd "${RUN_DIR}"/k8s/agent-scaler || exit 127
 cp "${RUN_DIR}"/joshua/joshua_model.py .
 docker build \
   --build-arg AGENT_TAG=foundationdb/joshua-agent:"${DATE_STR}-${COMMIT_HASH}" \
-  --build-arg FDB_VERSION="${FDB_VERSION}" \
+  ${fdb_version_arg} \
   --tag foundationdb/agent-scaler:"${DATE_STR}-${COMMIT_HASH}" \
   --tag foundationdb/agent-scaler:latest \
   .


### PR DESCRIPTION
When `FDB_VERSION` is passed as a shell variable or an environment variable, overwrite `FDB_VERSION` argument in the Dockerfile.
