### PR TITLE
Try: Use tmpfs folder as joshua agent work directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,6 @@ CMD source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-ruby27/enable && \
     python3 -m joshua.joshua_agent \
         -C ${FDB_CLUSTER_FILE} \
-        --work_dir /var/joshua \
+        --work_dir /dev/shm/joshua \
         --agent-idle-timeout ${AGENT_TIMEOUT}
 


### PR DESCRIPTION
I noticed that Joshua test has failure due to "Disk i/o error". This happens when Joshua agent process cannot write to its disk. This causes false-positive test failures (my guess).  

To confirm this, we can use a tmpfs folder as Joshua agent's work_dir. It can
1. Avoid the disk I/o error (hopefully);
2. Reduce each test's execution time due to faster disk access. 

I used `/dev/shm/` in this PR, which may or may not be the best choice. 
One caveat: we want to make sure the work folder is large enough to host the test temporary results. My gut feeling is that 1GB folder should be large enough. 