### PR TITLE
Try not to start more than "max_runs" runs

### DIFF
--- a/.github/workflows/joshua.yml
+++ b/.github/workflows/joshua.yml
@@ -1,0 +1,27 @@
+name: Joshua
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Install fdb and dependencies
+        run: |
+          wget https://www.foundationdb.org/downloads/6.3.12/ubuntu/installers/foundationdb-clients_6.3.12-1_amd64.deb --no-check-certificate
+          wget https://www.foundationdb.org/downloads/6.3.12/ubuntu/installers/foundationdb-server_6.3.12-1_amd64.deb --no-check-certificate
+          echo "05b11ac59cb44012e863113fa552c6cf53fb04cfbdb8e72a4a62770cbd2ddd81  foundationdb-clients_6.3.12-1_amd64.deb" >> checks.txt
+          echo "15472291c463c617f4f4f2c5e2fcb52ecb08757e481ee7f35e1b352999a7ea99  foundationdb-server_6.3.12-1_amd64.deb" >> checks.txt
+          sha256sum -c checks.txt && sudo dpkg -i *.deb
+          sudo pip3 install foundationdb lxml pytest
+
+      - name: Test
+        run: |
+          pytest -v

--- a/.pylintrc
+++ b/.pylintrc
@@ -298,7 +298,7 @@ max-module-lines=99999
 # spaces.  Google's externaly-published style guide says 4, consistent with
 # PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
 # projects (like TensorFlow).
-indent-string='  '
+indent-string='    '
 
 # Number of spaces of indent required inside a hanging  or continued line.
 indent-after-paren=4

--- a/.pylintrc
+++ b/.pylintrc
@@ -294,10 +294,7 @@ no-space-check=
 # Maximum number of lines in a module
 max-module-lines=99999
 
-# String used as indentation unit.  The internal Google style guide mandates 2
-# spaces.  Google's externaly-published style guide says 4, consistent with
-# PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
-# projects (like TensorFlow).
+# Use 4 spaces - consistent with PEP 8
 indent-string='    '
 
 # Number of spaces of indent required inside a hanging  or continued line.

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+from typing import Dict, Tuple
 from . import joshua_model, process_handling
 import argparse, errno, os, random, shutil, re, sys, tarfile, traceback, tempfile, time
 import subprocess32 as subprocess

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -379,8 +379,8 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
 
     log('{}{}{}'.format(ensemble, seed, command))
 
-    if not joshua_model.log_started_test(ensemble, seed, sanity):
-        log("<jobstopped>")
+    if not joshua_model.try_starting_test(ensemble, seed, sanity):
+        log("<job stopped or enough runs started>")
         return -3
 
     # Run the test and log output

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -378,7 +378,7 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
     # Set environment variable to use the created temporary directory as its temporary directory.
     env["TMP"] = os.path.join(where, "tmp")
 
-    log('{}{}{}'.format(ensemble, seed, command))
+    log('{} {} {}'.format(ensemble, seed, command))
 
     if not joshua_model.try_starting_test(ensemble, seed, sanity):
         log("<job stopped or enough runs started>")
@@ -403,7 +403,7 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
         try:
             output, _ = process.communicate(timeout=1)
             retcode = process.poll()
-            log(retcode)
+            log('exit code: {}'.format(retcode))
             #output = output.decode('utf-8')
 
             break

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -621,6 +621,7 @@ class EnsembleProgressTracker:
                     return False
                 elif time.time() - last_time < timeout + 10: # 10 second buffer to give the other agent a chance to end their run
                     # Don't start it yet - maybe the other agent hasn't timed out yet
+                    time.sleep(1) # Avoid polling too frequently
                     return False
                 else:
                     # started >= max_runs, but ended hasn't increased in more

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -623,6 +623,7 @@ def try_starting_test(tr, ensemble_id, seed, sanity=False) -> bool:
             if ended > last_ended:
                 _last_ensemble_progress[ensemble_id] = ended, time.time()
                 _last_ensemble_progress.move_to_end(ensemble_id)
+                return False
             elif time.time() - last_time < timeout + 10: # 10 second buffer to give the other agent a chance to end their run
                 # Don't start it yet - maybe the other agent hasn't timed out yet
                 return False

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -631,7 +631,7 @@ class EnsembleProgressTracker:
                 # We don't know whether or not another agent could have timed out. Start tracking it and don't start a new run.
                 self._last_ensemble_progress[ensemble_id] = ended, time.time()
                 # We inserted an ensemble into _last_ensemble_progress, so try to limit memory usage by expiring one.
-                oldest_list = list(islice(self._last_ensemble_progress.items(), 1))
+                oldest_list = list(islice(self._last_ensemble_progress.keys(), 1))
                 for oldest in oldest_list:
                     if tr[dir_active[oldest]] == None:
                         del self._last_ensemble_progress[oldest]

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -587,7 +587,7 @@ def _get_snap_counter(tr : fdb.Transaction, ensemble_id : str, counter : str) ->
 
 
 def _get_snap_max_runs(tr : fdb.Transaction, ensemble_id : str) -> int:
-    """Read max_runs for this ensemble at snapshot isolation. Precondition: ensemble exists."""
+    """Read max_runs for this ensemble at snapshot isolation. Returns a default of 0 if max_runs is not set"""
     result = tr.snapshot.get(dir_all_ensembles[ensemble_id]['properties']['max_runs'])
     if result == None:
         return 0
@@ -595,8 +595,11 @@ def _get_snap_max_runs(tr : fdb.Transaction, ensemble_id : str) -> int:
     return value
 
 def _get_snap_timeout(tr : fdb.Transaction, ensemble_id : str) -> int:
-    """Read timeout for this ensemble at snapshot isolation. Precondition: ensemble exists."""
-    value, = fdb.tuple.unpack(tr.snapshot.get(dir_all_ensembles[ensemble_id]['properties']['timeout']))
+    """Read timeout for this ensemble at snapshot isolation. Returns a default of 5400 if timeout is not set"""
+    result = tr.snapshot.get(dir_all_ensembles[ensemble_id]['properties']['timeout'])
+    if result == None:
+        return 0
+    value, = fdb.tuple.unpack(result)
     return value
 
 class EnsembleProgressTracker:

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -598,7 +598,7 @@ def _get_snap_timeout(tr : fdb.Transaction, ensemble_id : str) -> int:
     """Read timeout for this ensemble at snapshot isolation. Returns a default of 5400 if timeout is not set"""
     result = tr.snapshot.get(dir_all_ensembles[ensemble_id]['properties']['timeout'])
     if result == None:
-        return 0
+        return 5400
     value, = fdb.tuple.unpack(result)
     return value
 

--- a/test_joshua_model.py
+++ b/test_joshua_model.py
@@ -1,0 +1,215 @@
+import os
+import time
+import threading
+import io
+import threading
+import pytest
+import shutil
+import socket
+import subprocess
+import tempfile
+import joshua.joshua_model as joshua_model
+import joshua.joshua as joshua
+import joshua.joshua_agent as joshua_agent
+
+import fdb
+
+fdb.api_version(520)
+
+
+#################### Fixtures ####################
+# https://docs.pytest.org/en/stable/fixture.html
+
+
+def getFreePort():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("", 0))
+    addr = s.getsockname()
+    result = addr[1]
+    s.close()
+    return result
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fdb_cluster():
+    """
+    Provision an fdb cluster for the entire test session, and call
+    joshua_model.open() Tear down when the test session ends.
+    """
+    # Setup
+    tmp_dir = tempfile.mkdtemp()
+    port = getFreePort()
+    cluster_file = os.path.join(tmp_dir, "fdb.cluster")
+    with open(cluster_file, "w") as f:
+        f.write("abdcefg:abcdefg@127.0.0.1:{}".format(port))
+    proc = subprocess.Popen(
+        ["fdbserver", "-p", "auto:{}".format(port), "-C", cluster_file], cwd=tmp_dir
+    )
+
+    subprocess.check_output(
+        ["fdbcli", "-C", cluster_file, "--exec", "configure new single ssd"]
+    )
+
+    joshua_model.open(cluster_file)
+    yield cluster_file
+
+    # Teardown
+    proc.kill()
+    proc.wait()
+    shutil.rmtree(tmp_dir)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_db(fdb_cluster):
+    """
+    Clear the db before each test
+    """
+    subprocess.check_output(
+        ["fdbcli", "-C", fdb_cluster, "--exec", 'writemode on; clearrange "" \xff']
+    )
+
+
+#################### Tests ####################
+# Each function starting with `test_` will get
+# run by pytest, with an empty db.
+
+
+def test_create_ensemble():
+    assert len(joshua_model.list_active_ensembles()) == 0
+    joshua_model.create_ensemble("joshua", {}, io.BytesIO())
+    assert len(joshua_model.list_active_ensembles()) > 0
+
+
+def test_agent(tmp_path):
+    """
+    :tmp_path: https://docs.pytest.org/en/stable/tmpdir.html
+    """
+    assert len(joshua_model.list_active_ensembles()) == 0
+    ensemble_id = joshua_model.create_ensemble(
+        "joshua", {"max_runs": 1}, open("ensemble.tar.gz", "rb")
+    )
+    agent = threading.Thread(
+        target=joshua_agent.agent,
+        args=(),
+        kwargs={
+            "work_dir": tmp_path,
+            "agent_idle_timeout": 1,
+        },
+    )
+    agent.setDaemon(True)
+    agent.start()
+    joshua.tail_ensemble(ensemble_id, username="joshua")
+    agent.join()
+
+
+def test_dead_agent(tmp_path):
+    """
+    :tmp_path: https://docs.pytest.org/en/stable/tmpdir.html
+    """
+    assert len(joshua_model.list_active_ensembles()) == 0
+    ensemble_id = joshua_model.create_ensemble(
+        "joshua", {"max_runs": 1, "timeout": 1}, open("ensemble.tar.gz", "rb")
+    )
+    # simulate another agent dying after incrementing started but before incrementing ended
+    @fdb.transactional
+    def incr_start(tr):
+        joshua_model._increment(tr, ensemble_id, "started")
+
+    incr_start(joshua_model.db)
+
+    agent = threading.Thread(
+        target=joshua_agent.agent,
+        args=(),
+        kwargs={
+            "work_dir": tmp_path,
+            "agent_idle_timeout": 1,
+        },
+    )
+    agent.setDaemon(True)
+    agent.start()
+
+    # Ensemble should still eventually end
+    joshua.tail_ensemble(ensemble_id, username="joshua")
+    agent.join()
+
+
+def test_two_agents(tmp_path):
+    """
+    :tmp_path: https://docs.pytest.org/en/stable/tmpdir.html
+    """
+
+    @fdb.transactional
+    def get_started(tr):
+        return joshua_model._get_snap_counter(tr, ensemble_id, "started")
+
+    assert len(joshua_model.list_active_ensembles()) == 0
+    ensemble_id = joshua_model.create_ensemble(
+        "joshua", {"max_runs": 1, "timeout": 1}, open("ensemble.tar.gz", "rb")
+    )
+
+    agents = []
+    for rank in range(2):
+        agent = threading.Thread(
+            target=joshua_agent.agent,
+            args=(),
+            kwargs={
+                "work_dir": os.path.join(tmp_path, str(rank)),
+                "agent_idle_timeout": 1,
+            },
+        )
+        agent.setDaemon(True)
+        agent.start()
+        agents.append(agent)
+        # before starting agent two, wait until agent one has started on this ensemble
+        while get_started(joshua_model.db) != 1:
+            time.sleep(0.001)
+
+    joshua.tail_ensemble(ensemble_id, username="joshua")
+
+    @fdb.transactional
+    def get_started(tr):
+        return joshua_model._get_snap_counter(tr, ensemble_id, "started")
+
+    # The second agent won't have started this ensemble (unless somehow > 10
+    # seconds passed without the first agent completing the ensemble)
+    assert get_started(joshua_model.db) == 1
+
+    assert joshua_model._get_snap_max_runs
+
+    for agent in agents:
+        agent.join()
+
+
+def test_two_ensembles_memory_usage(tmp_path):
+    """
+    :tmp_path: https://docs.pytest.org/en/stable/tmpdir.html
+    """
+    assert len(joshua_model.list_active_ensembles()) == 0
+    ensemble_id = joshua_model.create_ensemble(
+        "joshua", {"max_runs": 1, "timeout": 1}, open("ensemble.tar.gz", "rb")
+    )
+    agent = threading.Thread(
+        target=joshua_agent.agent,
+        args=(),
+        kwargs={
+            "work_dir": tmp_path,
+            "agent_idle_timeout": 1,
+        },
+    )
+    agent.setDaemon(True)
+    agent.start()
+
+    # Ensemble one should eventually end
+    joshua.tail_ensemble(ensemble_id, username="joshua")
+
+    # Start ensemble two
+    ensemble_id = joshua_model.create_ensemble(
+        "joshua", {"max_runs": 1, "timeout": 1}, open("ensemble.tar.gz", "rb")
+    )
+
+    # inserting the second ensemble should remove the in-memory state for the first one
+    assert len(joshua_model._ensemble_progress_tracker._last_ensemble_progress) == 1
+
+    # Ensemble two should eventually end
+    joshua.tail_ensemble(ensemble_id, username="joshua")
+    agent.join()

--- a/test_joshua_model.py
+++ b/test_joshua_model.py
@@ -220,8 +220,6 @@ def test_two_agents(tmp_path, empty_ensemble):
     # seconds passed without the first agent completing the ensemble)
     assert get_started(joshua_model.db) == 1
 
-    assert joshua_model._get_snap_max_runs
-
     for agent in agents:
         agent.join()
 


### PR DESCRIPTION
Introduce new logic for "should I start a run for this ensemble?". Try not overshoot max_runs by too much, but still read started at snapshot isolation to avoid serializing starting all runs. In case an another agent dies after incrementing `started` but before incrementing `ended`, agents will allow runs to start once they haven't seen `ended` change for `timeout` + 10 seconds.

It's possible that we may also want to change the "which ensemble should I try next?" logic as well to decrease the probability of choosing an ensemble that already has `started >= max_runs`.

Closes #1 