### PR TITLE
Quick fix to ensure Joshua finishes its started tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,6 @@ CMD source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-ruby27/enable && \
     python3 -m joshua.joshua_agent \
         -C ${FDB_CLUSTER_FILE} \
-        --work_dir /dev/shm/joshua \
+        --work_dir /var/joshua \
         --agent-idle-timeout ${AGENT_TIMEOUT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,6 @@ CMD source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-ruby27/enable && \
     python3 -m joshua.joshua_agent \
         -C ${FDB_CLUSTER_FILE} \
-        --work_dir /var/joshua \
+        --work_dir /dev/shm/joshua \
         --agent-idle-timeout ${AGENT_TIMEOUT}
 

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -329,7 +329,7 @@ def cleanup(ensemble, where, seed, retcode=0, save_on='FAILURE', work_dir=None):
     # Clear the temporary directory.
     clear_directory(os.path.join(where, 'tmp'))
 
-
+# Run one random test for the emsemble
 def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeout_command_timeout=60):
     """
     Actually run the ensemble's test script.
@@ -351,6 +351,7 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
     timeout_command = properties.get('timeout_command', './joshua_timeout')
     timeout_time = properties.get('timeout', None)
     fail_fast = properties.get('fail_fast', 0)
+    # This is how to get the max_runs configured by user
     max_runs = properties.get('max_runs', 0)
 
     seed = random.getrandbits(63)
@@ -545,6 +546,14 @@ def agent(agent_timeout=None,
             if stopAgent():
                 log('Exiting due to global request')
                 break
+            # Break if the number of finished runs is larger than the max_runs
+            # Joshua agent stops spawning new tests when ended runs > max_runs
+            properties = joshua_model.get_ensemble_properties(ensemble)
+            max_runs = properties.get('max_runs', 0)
+            ended = joshua_model.get_snap_counter(ensemble, 'ended')
+            if ended > max_runs:
+                log('Exiting due to ended {} reaching max_runs {}'.format(ended, max_runs));
+                break;
 
             if (not watch) or watch.is_ready():
                 ensembles, watch = joshua_model.list_and_watch_active_ensembles(

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -579,6 +579,9 @@ def _get_snap_counter(tr, ensemble_id, counter):
     else:
         return struct.unpack("<Q", b'' + value)[0]
 
+@transactional
+def get_snap_counter(tr, ensemble_id, counter):
+    return _get_snap_counter(tr, ensemble_id, counter)
 
 @transactional
 def log_started_test(tr, ensemble_id, seed, sanity=False):
@@ -641,8 +644,10 @@ def _insert_results(tr,
 
     if max_runs > 0:
         # This is a snapshot read so that two insertions don't conflict.
+        # This is how we get the number of finished runs
         ended = _get_snap_counter(tr, ensemble_id, 'ended')
         if ended >= max_runs:
+            # Instead of stop ensemble, we should stop spawning new tests
             _stop_ensemble(tr, ensemble_id, sanity)
 
     if duration:

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -642,13 +642,13 @@ def _insert_results(tr,
         _increment(tr, ensemble_id, 'pass')
         results = dir_ensemble_results_pass
 
-    if max_runs > 0:
-        # This is a snapshot read so that two insertions don't conflict.
-        # This is how we get the number of finished runs
-        ended = _get_snap_counter(tr, ensemble_id, 'ended')
-        if ended >= max_runs:
-            # Instead of stop ensemble, we should stop spawning new tests
-            _stop_ensemble(tr, ensemble_id, sanity)
+    # if max_runs > 0:
+    #     # This is a snapshot read so that two insertions don't conflict.
+    #     # This is how we get the number of finished runs
+    #     ended = _get_snap_counter(tr, ensemble_id, 'ended')
+    #     if ended >= max_runs:
+    #         # Instead of stop ensemble, we should stop spawning new tests
+    #         _stop_ensemble(tr, ensemble_id, sanity)
 
     if duration:
         _add(tr, ensemble_id, 'duration', int(duration))


### PR DESCRIPTION

The problem today:
When user starts 100K tests, Joshua may spawn 200K tests and return success when it finishes 100K (successful) tests. The premature ending of test can ignore the real test failures which takes long time to finish. The problem gets worse when Joshua runs faster.

The quick-fix idea:
Let Joshua finish jobs that are currently running, even when it finishes 100K tests already. When user wants 100K tests, Joshua may spawn and run 110K tests. But all started tests will be logged. We shouldn't miss the long-running failed tests. 

Testing:
I didn't deploy it to a cluster for testing. This is DRAFT PR to share the idea. 

