### PR TITLE
Agent heartbeats and extra info about running tests

### DIFF
--- a/.github/workflows/joshua.yml
+++ b/.github/workflows/joshua.yml
@@ -15,12 +15,13 @@ jobs:
       
       - name: Install fdb and dependencies
         run: |
+          sudo mkdir -p /var/lib/foundationdb/data
           wget https://www.foundationdb.org/downloads/6.3.12/ubuntu/installers/foundationdb-clients_6.3.12-1_amd64.deb --no-check-certificate
           wget https://www.foundationdb.org/downloads/6.3.12/ubuntu/installers/foundationdb-server_6.3.12-1_amd64.deb --no-check-certificate
           echo "05b11ac59cb44012e863113fa552c6cf53fb04cfbdb8e72a4a62770cbd2ddd81  foundationdb-clients_6.3.12-1_amd64.deb" >> checks.txt
           echo "15472291c463c617f4f4f2c5e2fcb52ecb08757e481ee7f35e1b352999a7ea99  foundationdb-server_6.3.12-1_amd64.deb" >> checks.txt
           sha256sum -c checks.txt && sudo dpkg -i *.deb
-          sudo pip3 install foundationdb lxml pytest
+          sudo pip3 install foundationdb lxml pytest python-dateutil
 
       - name: Test
         run: |

--- a/.github/workflows/joshua.yml
+++ b/.github/workflows/joshua.yml
@@ -21,7 +21,7 @@ jobs:
           echo "05b11ac59cb44012e863113fa552c6cf53fb04cfbdb8e72a4a62770cbd2ddd81  foundationdb-clients_6.3.12-1_amd64.deb" >> checks.txt
           echo "15472291c463c617f4f4f2c5e2fcb52ecb08757e481ee7f35e1b352999a7ea99  foundationdb-server_6.3.12-1_amd64.deb" >> checks.txt
           sha256sum -c checks.txt && sudo dpkg -i *.deb
-          sudo pip3 install foundationdb lxml pytest python-dateutil
+          sudo pip3 install -r test-requirements.txt
 
       - name: Test
         run: |

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -87,7 +87,7 @@ def get_active_ensembles(stopped, sanity=False, username=None):
     return ensemble_list
 
 
-def list_active_ensembles(stopped, sanity=False, username=None, **args):
+def list_active_ensembles(stopped, sanity=False, username=None, show_in_progress=None, **args):
     ensemble_list = get_active_ensembles(stopped, sanity, username)
     if stopped:
         print('All ensembles:')
@@ -97,7 +97,20 @@ def list_active_ensembles(stopped, sanity=False, username=None, **args):
         print('Currently active ensembles:')
     for e, props in ensemble_list:
         print(format_ensemble(e, props))
+        print('\tCurrently active tests:')
+        if show_in_progress:
+            for props in joshua_model.show_in_progress(e):
+                print('\t{}'.format(' '.join('{}={}'.format(k, v) for k, v in sorted(props.items()))))
+
     return ensemble_list
+
+
+def show_in_progress(ensemble=None, sanity=False, username=None, **kwargs):
+    if ensemble is None:
+        ensemble = [e for e, _ in joshua_model.list_active_ensembles()]
+    print(ensemble)
+    for e in ensemble:
+        print(e, joshua_model.show_in_progress(ensemble))
 
 
 def start_ensemble(tarball,
@@ -445,6 +458,10 @@ if __name__ == "__main__":
     parser_list.add_argument('--username',
                              metavar='user',
                              help='username of user who launched the test',
+                             default=None)
+    parser_list.add_argument('--show-in-progress',
+                             action='store_true',
+                             help='If set, show the progress of currently running tests',
                              default=None)
     parser_list.set_defaults(cmd=list_active_ensembles)
 

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -97,8 +97,8 @@ def list_active_ensembles(stopped, sanity=False, username=None, show_in_progress
         print('Currently active ensembles:')
     for e, props in ensemble_list:
         print(format_ensemble(e, props))
-        print('\tCurrently active tests:')
         if show_in_progress:
+            print('\tCurrently active tests:')
             for props in joshua_model.show_in_progress(e):
                 print('\t{}'.format(' '.join('{}={}'.format(k, v) for k, v in sorted(props.items()))))
 

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -105,14 +105,6 @@ def list_active_ensembles(stopped, sanity=False, username=None, show_in_progress
     return ensemble_list
 
 
-def show_in_progress(ensemble=None, sanity=False, username=None, **kwargs):
-    if ensemble is None:
-        ensemble = [e for e, _ in joshua_model.list_active_ensembles()]
-    print(ensemble)
-    for e in ensemble:
-        print(e, joshua_model.show_in_progress(ensemble))
-
-
 def start_ensemble(tarball,
                    command,
                    properties,

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -410,7 +410,7 @@ def run_ensemble(ensemble, save_on='FAILURE', sanity=False, work_dir=None, timeo
         except subprocess.TimeoutExpired:
             # The "timeout" is just an opportunity to poll the database to see if this ensemble has been stopped
             # Possibly in the future we will implement an actual timeout option
-            if not joshua_model.test_running(ensemble, seed, sanity):
+            if not joshua_model.heartbeat_and_check_running(ensemble, seed, sanity):
                 log("<cancelled>")
                 retcode = -1
                 output = b""

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,17 @@
+attrs==20.3.0
+foundationdb==6.3.12
+importlib-metadata==4.0.1
+iniconfig==1.1.1
+lxml==4.6.3
+packaging==20.9
+pluggy==0.13.1
+psutil==5.8.0
+py==1.10.0
+pyparsing==2.4.7
+pytest==6.2.3
+python-dateutil==2.8.1
+six==1.15.0
+subprocess32==3.5.4
+toml==0.10.2
+typing-extensions==3.10.0.0
+zipp==3.4.1

--- a/test_joshua_model.py
+++ b/test_joshua_model.py
@@ -156,12 +156,9 @@ def test_dead_agent(tmp_path, empty_ensemble):
     ensemble_id = joshua_model.create_ensemble(
         "joshua", {"max_runs": 1, "timeout": 1}, open(empty_ensemble, "rb")
     )
-    # simulate another agent dying after incrementing started but before incrementing ended
-    @fdb.transactional
-    def incr_start(tr):
-        joshua_model._increment(tr, ensemble_id, "started")
 
-    incr_start(joshua_model.db)
+    # simulate another agent dying after starting a test
+    assert joshua_model.try_starting_test(ensemble_id, 12345)
 
     agent = threading.Thread(
         target=joshua_agent.agent,
@@ -250,9 +247,6 @@ def test_two_ensembles_memory_usage(tmp_path, empty_ensemble):
     ensemble_id = joshua_model.create_ensemble(
         "joshua", {"max_runs": 1, "timeout": 1}, open(empty_ensemble, "rb")
     )
-
-    # inserting the second ensemble should remove the in-memory state for the first one
-    assert len(joshua_model._ensemble_progress_tracker._last_ensemble_progress) == 1
 
     # Ensemble two should eventually end
     joshua.tail_ensemble(ensemble_id, username="joshua")


### PR DESCRIPTION
Add agent heartbeats, use agent heartbeats for deciding whether or not an agent died, and add `--show-in-progress` flag to the `list` command which gives you extra insight into currently running tests.

Closes #21 

```
$ python3 -m joshua.joshua list --show-in-progress
Currently active ensembles:
  20210429-181606-anoyes-cfd4dc468251a82a            compressed=True data_size=16828099 duration=1378 ended=65 fail=3 fail_fast=10 max_runs=100000 pass=62 priority=100 remaining=22 days, 19:56:03 runtime=0:21:23 sanity=False started=67
submitted=20210429-181606 timeout=5400 username=anoyes
        Currently active tests:
        began_at=1619721418.6287942 heartbeat=1619721449.7608917 hostname=DEVVM-anoyes running_for=31.348735570907593 seed=6124025125060707282
        began_at=1619721449.5082393 heartbeat=1619721449.5082393 hostname=DEVVM-anoyes running_for=0.46973276138305664 seed=6709479366317872481
```