### PR TITLE
Fix: deleting an ensemble could corrupt joshua's data model

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -695,6 +695,10 @@ def _insert_results(tr,
                     duration=0):
     dir, _ = get_dir_changes(sanity)
 
+    if tr[dir[ensemble_id]] == None:
+        # Don't insert any more results for stopped ensembles
+        return False
+
     if tr[dir_ensemble_incomplete[ensemble_id][seed]] == None:
         # Test already completed
         return False
@@ -702,10 +706,6 @@ def _insert_results(tr,
     del tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][seed]]
 
     _increment(tr, ensemble_id, 'ended')
-
-    if tr[dir[ensemble_id]] == None:
-        # Don't insert any more results for stopped ensembles
-        return False
 
     if result_code:
         _increment(tr, ensemble_id, 'fail')

--- a/test_joshua_model.py
+++ b/test_joshua_model.py
@@ -324,3 +324,6 @@ def test_delete_ensemble(tmp_path, empty_ensemble_timeout):
     joshua_model.delete_ensemble(ensemble_id)
     time.sleep(1)  # Wait for long enough that agents timeout
     assert len(joshua_model.list_all_ensembles()) == 0
+
+    for agent in agents:
+        agent.join()


### PR DESCRIPTION
Agents would previously increment 'ended' for ensembles that were deleted, which violated assumptions `joshua list --stopped` makes about the data model.

Add a test that fails before the fix and passes after the fix