### PR TITLE
Replace Invalid UTF-8 characters with \x??

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -830,7 +830,7 @@ def tail_results(ensemble_id, errors_only=False, compressed=True):
             begin_versionstamp = block[-1][0] + 1
             for item in block:
                 text = item[-1] if not compressed else zlib.decompress(item[-1])
-                text = text.decode(encoding='utf-8')
+                text = text.decode(encoding='utf-8', errors='backslashreplace')
                 new_item = item[:-1] + (text,)
 
                 if is_message(text):


### PR DESCRIPTION
Sometimes a test may output invalid UTF-8 characters, which will crash Joshua previously because Joshua assumes all outputs are UTF-8. This PR fixes this problem by replacing invalid UTF-8 characters with \x??.