### PR TITLE
Commented out tls library temporarily until it's hosted again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN if [ "$(uname -p)" == "x86_64" ]; then \
         chmod +x ${OLD_FDB_BINARY_DIR}/* && \
         # curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | tar -xz -C ${OLD_TLS_LIBRARY_DIR} --strip-components=1 && \
         curl -Ls https://www.foundationdb.org/downloads/${FDB_VERSION}/linux/libfdb_c_${FDB_VERSION}.so -o /usr/lib64/libfdb_c_${FDB_VERSION}.so && \
-        ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so && \
+        ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so \
         # ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
         # ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/FDBGnuTLS.so; \
         fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,11 +82,11 @@ RUN if [ "$(uname -p)" == "x86_64" ]; then \
         curl -Ls https://www.foundationdb.org/downloads/misc/fdbservers-${OLD_FDB_VERSIONS}.tar.gz | tar -xz -C ${OLD_FDB_BINARY_DIR} && \
         rm -f ${OLD_FDB_BINARY_DIR}/*.sha256 && \
         chmod +x ${OLD_FDB_BINARY_DIR}/* && \
-        curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | tar -xz -C ${OLD_TLS_LIBRARY_DIR} --strip-components=1 && \
+        # curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | tar -xz -C ${OLD_TLS_LIBRARY_DIR} --strip-components=1 && \
         curl -Ls https://www.foundationdb.org/downloads/${FDB_VERSION}/linux/libfdb_c_${FDB_VERSION}.so -o /usr/lib64/libfdb_c_${FDB_VERSION}.so && \
         ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so && \
-        ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
-        ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/FDBGnuTLS.so; \
+        # ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
+        # ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/FDBGnuTLS.so; \
         fi
 
 ENV FDB_CLUSTER_FILE=/etc/foundationdb/fdb.cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN if [ "$(uname -p)" == "x86_64" ]; then \
         chmod +x ${OLD_FDB_BINARY_DIR}/* && \
         # curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | tar -xz -C ${OLD_TLS_LIBRARY_DIR} --strip-components=1 && \
         curl -Ls https://www.foundationdb.org/downloads/${FDB_VERSION}/linux/libfdb_c_${FDB_VERSION}.so -o /usr/lib64/libfdb_c_${FDB_VERSION}.so && \
-        ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so \
+        ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so; \
         # ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
         # ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/FDBGnuTLS.so; \
         fi


### PR DESCRIPTION
`joshua_tls_library.tar.gz` tar-file contains TLS binaries for older FDB binaries, specifically <= 5.2, because at that time TLS was not linked to (part of) the `fdbserver` binary.

On 08/31 we noticed this file is no longer hosted at https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz. Hence, commenting out these lines and reverting once it's hosted again. We will work around it for the time-being.