### PR TITLE
Download kubectl version based on host arch

### DIFF
--- a/k8s/agent-scaler/Dockerfile
+++ b/k8s/agent-scaler/Dockerfile
@@ -12,7 +12,7 @@ RUN yum repolist && \
         gettext \
         rh-python38 \
         rh-python38-python-pip && \
-    curl -Ls https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl \
+    curl -Ls https://dl.k8s.io/release/v1.20.0/bin/linux/$(uname -p)/kubectl \
          -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
Currently kubectl will always use amd64 arch, this change will use the host arch to determine which binary of kubectl to install

Tested by running `./build.sh` locally to confirm it can at least build amd64 version of arch. Verified other arches are available at download site such as:

- https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl
- https://dl.k8s.io/release/v1.20.0/bin/linux/arm64/kubectl