### PR TITLE
Let agents to exit when enough agents are serving existing ensembles

### DIFF
--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -683,20 +683,16 @@ def agent(agent_timeout=None,
             ensembles_can_run = None
             if ensembles:
                 ensembles_can_run = list(filter(joshua_model.should_run_ensemble, ensembles))
-                if not ensembles_can_run:
-                    # All the ensembles have enough runs started for now. Don't
-                    # time the agent out, just wait until there are no
-                    # ensembles or the other agents might have died.
-                    time.sleep(1)
-                    continue
-            else:
-                # No ensembles at all. Consider timing this agent out.
-                try:
-                    watch.wait_for_any(watch, sanity_watch, TimeoutFuture(1.0))
-                except Exception as e:
-                    log("watch error: {}".format(e))
-                    watch = None
-                    time.sleep(1.0)
+
+            if not ensembles or (ensembles and not ensembles_can_run):
+                if not ensemble:
+                    # No ensembles at all. Consider timing this agent out.
+                    try:
+                        watch.wait_for_any(watch, sanity_watch, TimeoutFuture(1.0))
+                    except Exception as e:
+                        log("watch error: {}".format(e))
+                        watch = None
+                        time.sleep(1.0)
 
                 # End the loop if we have exceeded the time given.
                 now = time.time()

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -460,7 +460,7 @@ def get_active_ensembles(stopped, sanity=False, username=None) -> List[Tuple[str
                     props['remaining'] = "stopping"
                 else:
                     props['remaining'] = format_timedelta(
-                        datetime.timedelta(
+                        timedelta(
                             seconds=load_timedelta(
                                 props['runtime']).total_seconds() *
                             (int(props['max_runs']) - jobs_done) / jobs_done))

--- a/tests/sanity_test.sh
+++ b/tests/sanity_test.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-docker run -t --rm --name joshua-test -u root:root -v $(pwd):/joshua foundationdb/joshua-agent:latest /joshua/sanity_test_script.sh
+tag=latest
+if [ $# -eq 1 ]; then
+    tag=$1
+fi
+docker run -t --rm --name joshua-test -u root:root -v $(pwd):/joshua foundationdb/joshua-agent:${tag} /joshua/sanity_test_script.sh
 rc=$?
 if [ $rc -eq 0 ]; then
     echo "PASSED!"


### PR DESCRIPTION
When there are enough agents running for the existing ensembles,
other agents were waiting in a sleep loop in case some running agents die.

e.g. When you run 100 agents and there are 8 tests remained,
8 agents will be performing the tests and 92 agents will simply sit there in a `sleep 1` loop.
When those 8 agents finish, the other 92 agents will also exit.

However, the problem is, when another ensemble with `max-run=50` is submitted when those 92 agents are sleeping,
50 agents will pick up the new tests, but 42 agents will continue to sleep.
This is extremely inefficient.

This PR will allow agents to exit if enough agents are running.
If some agents die, then agent scaler will spin up new agents on k8s. Or other running agents will pick up the cancelled job when it finishes its current job.