### PR TITLE
Fix timedelta not found bug

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -460,7 +460,7 @@ def get_active_ensembles(stopped, sanity=False, username=None) -> List[Tuple[str
                     props['remaining'] = "stopping"
                 else:
                     props['remaining'] = format_timedelta(
-                        datetime.timedelta(
+                        timedelta(
                             seconds=load_timedelta(
                                 props['runtime']).total_seconds() *
                             (int(props['max_runs']) - jobs_done) / jobs_done))


### PR DESCRIPTION
datetime can be a package or object. We need to avoid using `datetime` when use timedelta objet. 

Otherwise, I got the following error 
```
# python3 -m joshua.joshua list --stop
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/root/src/fdb-joshua/joshua/joshua.py", line 53, in list_active_ensembles
    ensemble_list = get_active_ensembles(stopped, sanity, username)
  File "/root/src/fdb-joshua/joshua/joshua.py", line 49, in get_active_ensembles
    return joshua_model.get_active_ensembles(stopped, sanity, username)
  File "/root/src/fdb-joshua/joshua/joshua_model.py", line 463, in get_active_ensembles
    datetime.timedelta(
AttributeError: type object 'datetime.datetime' has no attribute 'timedelta'
```