### PR TITLE
Bug fix

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -460,7 +460,7 @@ def get_active_ensembles(stopped, sanity=False, username=None) -> List[Tuple[str
                     props['remaining'] = "stopping"
                 else:
                     props['remaining'] = format_timedelta(
-                        datetime.timedelta(
+                        timedelta(
                             seconds=load_timedelta(
                                 props['runtime']).total_seconds() *
                             (int(props['max_runs']) - jobs_done) / jobs_done))


### PR DESCRIPTION
This [PR](https://github.com/FoundationDB/fdb-joshua/pull/50) did some necessary refactoring, however a bug surfaces as this joshua_model.get_active_ensembles() is now getting called.

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/mnt/jenkins/home/jenkins/workspace/FDB_Joshua/joshua/joshua.py", line 53, in list_active_ensembles
    ensemble_list = get_active_ensembles(stopped, sanity, username)
  File "/mnt/jenkins/home/jenkins/workspace/FDB_Joshua/joshua/joshua.py", line 49, in get_active_ensembles
    return joshua_model.get_active_ensembles(stopped, sanity, username)
  File "/mnt/jenkins/home/jenkins/workspace/FDB_Joshua/joshua/joshua_model.py", line 463, in get_active_ensembles
    datetime.timedelta(
AttributeError: type object 'datetime.datetime' has no attribute 'timedelta'
```