### PR TITLE
code format cleanup

### DIFF
--- a/childsubreaper/setup.py
+++ b/childsubreaper/setup.py
@@ -1,6 +1,6 @@
-#
-# setup.py
-#
+"""
+    setup.py
+"""
 # This source file is part of the FoundationDB open source project
 #
 # Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
@@ -17,18 +17,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from distutils.core import setup, Extension
 
 import os.path
+
 file_dir = os.path.dirname(__file__)
 
-childsubreaper = Extension('childsubreaper',
-                           sources=[os.path.join(file_dir, 'childsubreaper.c')])
-setup(name='childsubreaper',
-      version='1.0',
-      author='The FoundationDB Team',
-      author_email='fdbteam@apple.com',
-      description=
-      'This wraps the prctl command to set a process as the child subreaper',
-      ext_modules=[childsubreaper])
+childsubreaper = Extension(
+    "childsubreaper", sources=[os.path.join(file_dir, "childsubreaper.c")]
+)
+setup(
+    name="childsubreaper",
+    version="1.0",
+    author="The FoundationDB Team",
+    author_email="fdbteam@apple.com",
+    description="This wraps the prctl command to set a process as the child subreaper",
+    ext_modules=[childsubreaper],
+)

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -19,13 +19,17 @@
 # limitations under the License.
 #
 
-from . import joshua_model
 import argparse
-import dateutil.parser, time
-from datetime import datetime, timedelta, timezone
-import os, pwd, sys
+import datetime
+import os
+import pwd
+import sys
 import threading
+import time
+
+import dateutil.parser
 import lxml.etree as le
+from . import joshua_model
 
 JOSHUA_USER_ENV = "JOSHUA_USER"
 
@@ -347,7 +351,7 @@ def delete_ensemble_range(
         # Parse the date to see if the ensemble is within the given range.
         try:
             timestamp = time.mktime(
-                datetime.strptime(
+                datetime.datetime.strptime(
                     "".join(ensemble.split("-")[:2]), "%Y%m%d%H%M%S"
                 ).timetuple()
             )

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-#
-# joshua.py
-#
+"""
+    joshua.py
+"""
 # This source file is part of the FoundationDB open source project
 #
 # Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
@@ -27,7 +27,7 @@ import os, pwd, sys
 import threading
 import lxml.etree as le
 
-JOSHUA_USER_ENV = 'JOSHUA_USER'
+JOSHUA_USER_ENV = "JOSHUA_USER"
 
 
 def get_username():
@@ -35,98 +35,107 @@ def get_username():
 
 
 def format_ensemble(e, props):
-    return "  %-50s %s" % (e, " ".join(
-        '{}={}'.format(k, v) for k, v in sorted(props.items())))
+    return "  %-50s %s" % (
+        e,
+        " ".join("{}={}".format(k, v) for k, v in sorted(props.items())),
+    )
 
 
 def timestamp_of(time_string):
     # FIXME: Right now this only uses local time. It should probably handle timezones/DST better.
-    return int(time.mktime(dateutil.parser.parse(
-        time_string).timetuple())) if time_string is not None else None
+    return (
+        int(time.mktime(dateutil.parser.parse(time_string).timetuple()))
+        if time_string is not None
+        else None
+    )
 
 
 def get_active_ensembles(stopped, sanity=False, username=None):
     return joshua_model.get_active_ensembles(stopped, sanity, username)
 
 
-def list_active_ensembles(stopped, sanity=False, username=None, show_in_progress=None, **args):
+def list_active_ensembles(
+    stopped, sanity=False, username=None, show_in_progress=None, **args
+):
     ensemble_list = get_active_ensembles(stopped, sanity, username)
     if stopped:
-        print('All ensembles:')
+        print("All ensembles:")
     elif sanity:
-        print('Currently active sanity ensembles:')
+        print("Currently active sanity ensembles:")
     else:
-        print('Currently active ensembles:')
+        print("Currently active ensembles:")
     for e, props in ensemble_list:
         print(format_ensemble(e, props))
         if show_in_progress:
-            print('\tCurrently active tests:')
+            print("\tCurrently active tests:")
             for props in joshua_model.show_in_progress(e):
-                print('\t{}'.format(' '.join('{}={}'.format(k, v) for k, v in sorted(props.items()))))
+                print(
+                    "\t{}".format(
+                        " ".join("{}={}".format(k, v) for k, v in sorted(props.items()))
+                    )
+                )
 
     return ensemble_list
 
 
-def start_ensemble(tarball,
-                   command,
-                   properties,
-                   username,
-                   compressed,
-                   allow_multiple=False,
-                   sanity=False,
-                   timeout=5400,
-                   no_timeout=False,
-                   fail_fast=10,
-                   no_fail_fast=False,
-                   max_runs=100000,
-                   no_max_runs=False,
-                   priority=100,
-                   env=[],
-                   printable=True,
-                   **args):
+def start_ensemble(
+    tarball,
+    command,
+    properties,
+    username,
+    compressed,
+    allow_multiple=False,
+    sanity=False,
+    timeout=5400,
+    no_timeout=False,
+    fail_fast=10,
+    no_fail_fast=False,
+    max_runs=100000,
+    no_max_runs=False,
+    priority=100,
+    env=[],
+    printable=True,
+    **args
+):
     if not allow_multiple:
         stop_ensemble(username=username, sanity=sanity, printable=True)
     properties = dict(p.split("=", 1) for p in properties)
-    properties['username'] = username
-    properties['compressed'] = compressed
-    properties['sanity'] = sanity
-    properties['priority'] = priority
+    properties["username"] = username
+    properties["compressed"] = compressed
+    properties["sanity"] = sanity
+    properties["priority"] = priority
     if env:
         # omit 'env' property if nothing is set
-        properties['env'] = ':'.join(env)
+        properties["env"] = ":".join(env)
 
     if not no_timeout:
-        properties['timeout'] = timeout
+        properties["timeout"] = timeout
 
     if fail_fast > 0 and not no_fail_fast:
-        print('Note: Ensemble will complete after {} failed results.'.format(
-            fail_fast))
-        properties['fail_fast'] = fail_fast
+        print("Note: Ensemble will complete after {} failed results.".format(fail_fast))
+        properties["fail_fast"] = fail_fast
 
     if max_runs > 0 and not no_max_runs:
-        print('Note: Ensemble will complete after {} runs.'.format(max_runs))
-        properties['max_runs'] = max_runs
+        print("Note: Ensemble will complete after {} runs.".format(max_runs))
+        properties["max_runs"] = max_runs
 
     if command:
-        properties['test_command'] = command
-    print('Starting ensemble')
+        properties["test_command"] = command
+    print("Starting ensemble")
     with open(tarball, "rb") as tarfile:
         tarfile.seek(0, os.SEEK_END)
         size = tarfile.tell()
         tarfile.seek(0, os.SEEK_SET)
-        properties['data_size'] = size
+        properties["data_size"] = size
 
-        ensemble_id = joshua_model.create_ensemble(username, properties,
-                                                   tarfile, sanity)
+        ensemble_id = joshua_model.create_ensemble(
+            username, properties, tarfile, sanity
+        )
     print(format_ensemble(ensemble_id, properties))
     return str(ensemble_id)
 
 
-def stop_ensemble(ensemble=None,
-                  username=None,
-                  sanity=False,
-                  printable=True,
-                  **args):
+def stop_ensemble(ensemble=None, username=None, sanity=False, printable=True, **args):
     if ensemble:
         if printable:
             print("Stopping ensemble", ensemble)
@@ -136,8 +145,11 @@ def stop_ensemble(ensemble=None,
         if not username:
             username = get_username()
         if printable:
-            ensemble_list = joshua_model.list_sanity_ensembles(
-            ) if sanity else joshua_model.list_active_ensembles()
+            ensemble_list = (
+                joshua_model.list_sanity_ensembles()
+                if sanity
+                else joshua_model.list_active_ensembles()
+            )
         else:
             ensemble_list = get_active_ensembles(False, sanity, username)
 
@@ -149,14 +161,15 @@ def stop_ensemble(ensemble=None,
 
 
 def default_ensemble(sanity=False, **args):
-    username = args.get('username') or get_username()
+    username = args.get("username") or get_username()
     all_ensembles = [
-        e for e, props in get_active_ensembles(True, False, False)
-        if props.get('username', None) == username and
-        props.get('sanity', False) == sanity
+        e
+        for e, props in get_active_ensembles(True, False, False)
+        if props.get("username", None) == username
+        and props.get("sanity", False) == sanity
     ]
     if not all_ensembles:
-        raise Exception('No tests have ever run for username ' + username)
+        raise Exception("No tests have ever run for username " + username)
     return all_ensembles[-1]
 
 
@@ -170,38 +183,37 @@ def resume_ensemble(ensemble, sanity=False, **args):
         print("Already running: ", ensemble, sanity)
 
 
-def tail_ensemble(ensemble,
-                  raw=False,
-                  errors_only=False,
-                  xml=False,
-                  sanity=False,
-                  simple=False,
-                  stopped=False,
-                  username=None,
-                  **args):
+def tail_ensemble(
+    ensemble,
+    raw=False,
+    errors_only=False,
+    xml=False,
+    sanity=False,
+    simple=False,
+    stopped=False,
+    username=None,
+    **args
+):
     if simple:
         xml = True
     if not ensemble:
         if not username:
-            username = args.get('username') or get_username()
-        ensembles = [
-            e for e, props in get_active_ensembles(stopped, sanity, username)
-        ]
+            username = args.get("username") or get_username()
+        ensembles = [e for e, props in get_active_ensembles(stopped, sanity, username)]
         ensemble = ensembles[-1] if ensembles else None
         if not ensemble:
             sys.stderr.write("No active ensembles\n")
             return
 
     properties = joshua_model.get_ensemble_properties(ensemble)
-    compressed = properties[
-        'compressed'] if 'compressed' in properties else False
+    compressed = properties["compressed"] if "compressed" in properties else False
 
     sys.stderr.write("Results for test ensemble: %s\n" % ensemble)
     if xml:
         sys.stdout.write("<Trace>")
-    for rec in joshua_model.tail_results(ensemble,
-                                         errors_only=errors_only,
-                                         compressed=compressed):
+    for rec in joshua_model.tail_results(
+        ensemble, errors_only=errors_only, compressed=compressed
+    ):
         if len(rec) == 5:
             versionstamp, result_code, host, seed, output = rec
         elif len(rec) == 4:
@@ -222,18 +234,21 @@ def tail_ensemble(ensemble,
 
         if simple:
             try:
-                doc = le.fromstring('<Dummy>' + output + '</Dummy>')
-                for elem in doc.xpath('//CodeCoverage'):
+                doc = le.fromstring("<Dummy>" + output + "</Dummy>")
+                for elem in doc.xpath("//CodeCoverage"):
                     elem.getparent().remove(elem)
-                for elem in doc.xpath('//BuggifySection'):
+                for elem in doc.xpath("//BuggifySection"):
                     elem.getparent().remove(elem)
                 for elem in doc.xpath('//*[(@Severity="30")]'):
                     elem.getparent().remove(elem)
                 output = le.tostring(doc).decode("utf-8")[7:-8]
                 parsed = True
             except Exception as e:
-                print('Could not parse xml output ({}) {} on {} because {}'.
-                      format(result_code, seed, host, e))
+                print(
+                    "Could not parse xml output ({}) {} on {} because {}".format(
+                        result_code, seed, host, e
+                    )
+                )
                 raise
 
         if raw or xml:
@@ -243,62 +258,65 @@ def tail_ensemble(ensemble,
             print(hex(versionstamp), result_code, host, seed, repr(output))
     if xml:
         sys.stdout.write("</Trace>")
-    sys.stderr.write('Ensemble stopped\n')
+    sys.stderr.write("Ensemble stopped\n")
 
 
 def agent_failures(start=None, end=None, **args):
     # Parse date times.
-    time_start = timestamp_of(start) if start is not None else int(time.time() -
-                                                                   60 * 60 *
-                                                                   24 * 7)
+    time_start = (
+        timestamp_of(start)
+        if start is not None
+        else int(time.time() - 60 * 60 * 24 * 7)
+    )
     time_end = timestamp_of(end)
 
     # Get the list of failures from the database.
     failures = joshua_model.get_agent_failures(time_start, time_end)
 
     if len(failures) == 0:
-        print('No failures found in specified date range.')
+        print("No failures found in specified date range.")
 
     for failure in failures:
-        print('   '.join(failure[0]))
-        print('\n'.join(
-            map(lambda x: (b'    ' + x).decode("utf-8"), failure[1].split(b'\n')
-               )))  # This indents the the string for visual appealingness.
+        print("   ".join(failure[0]))
+        print(
+            "\n".join(
+                map(lambda x: (b"    " + x).decode("utf-8"), failure[1].split(b"\n"))
+            )
+        )  # This indents the the string for visual appealingness.
 
 
 def _delete_helper(to_delete, yes=False, dryrun=False, sanity=False):
-    print('Found the following ensembles to delete:')
+    print("Found the following ensembles to delete:")
     for ensemble in to_delete:
         print(ensemble)
 
     print()
 
     if not yes and not dryrun:
-        response = input('Do you want to delete these ensembles [y/n]? ')
-        if response.strip().lower() not in set(['y', 'yes']):
-            print('Negative response received. Not performing deletion.')
+        response = input("Do you want to delete these ensembles [y/n]? ")
+        if response.strip().lower() not in set(["y", "yes"]):
+            print("Negative response received. Not performing deletion.")
             return
 
     # Actually delete these ensembles.
     for ensemble in to_delete:
         properties = joshua_model.get_ensemble_properties(ensemble)
-        compressed = properties[
-            'compressed'] if 'compressed' in properties else False
-        ensemble_sanity = properties[
-            'sanity'] if 'sanity' in properties else False
+        compressed = properties["compressed"] if "compressed" in properties else False
+        ensemble_sanity = properties["sanity"] if "sanity" in properties else False
 
         if not ensemble_sanity or sanity:
             if not dryrun:
-                joshua_model.delete_ensemble(ensemble,
-                                             compressed=compressed,
-                                             sanity=ensemble_sanity)
-                print('Ensemble', ensemble, 'deleted')
+                joshua_model.delete_ensemble(
+                    ensemble, compressed=compressed, sanity=ensemble_sanity
+                )
+                print("Ensemble", ensemble, "deleted")
             else:
-                print('Ensemble', ensemble, 'not deleted (dry-run).')
+                print("Ensemble", ensemble, "not deleted (dry-run).")
         else:
             print(
-                'Ensemble', ensemble,
-                'is a sanity ensemble and the sanity flag is not set. Skipping.'
+                "Ensemble",
+                ensemble,
+                "is a sanity ensemble and the sanity flag is not set. Skipping.",
             )
 
 
@@ -307,25 +325,20 @@ def delete_ensembles(ensembles, yes=False, dryrun=False, sanity=False, **args):
     to_delete = joshua_model.identify_existing_ensembles(ensembles)
 
     if len(to_delete) == 0:
-        print(
-            'None of the specified ensembles currently exist. Not deleting any runs.'
-        )
+        print("None of the specified ensembles currently exist. Not deleting any runs.")
         return
 
     _delete_helper(to_delete, yes, dryrun, sanity)
 
 
-def delete_ensemble_range(before=None,
-                          after=None,
-                          yes=False,
-                          dryrun=False,
-                          sanity=False,
-                          **args):
+def delete_ensemble_range(
+    before=None, after=None, yes=False, dryrun=False, sanity=False, **args
+):
     time_before = timestamp_of(before)
     time_after = timestamp_of(after)
 
     if time_before is None and time_after is None:
-        print('Empty range specified. Not deleting any runs.')
+        print("Empty range specified. Not deleting any runs.")
         return
 
     to_delete = []
@@ -334,18 +347,19 @@ def delete_ensemble_range(before=None,
         # Parse the date to see if the ensemble is within the given range.
         try:
             timestamp = time.mktime(
-                datetime.strptime(''.join(ensemble.split('-')[:2]),
-                                  '%Y%m%d%H%M%S').timetuple())
-            if (time_before is None or
-                    timestamp < time_before) and (time_after is None or
-                                                  timestamp > time_after):
+                datetime.strptime(
+                    "".join(ensemble.split("-")[:2]), "%Y%m%d%H%M%S"
+                ).timetuple()
+            )
+            if (time_before is None or timestamp < time_before) and (
+                time_after is None or timestamp > time_after
+            ):
                 to_delete.append(ensemble)
         except Exception as e:
-            print('Could not parse datetime from ensemble:', ensemble,
-                  'Skipping.')
+            print("Could not parse datetime from ensemble:", ensemble, "Skipping.")
 
     if len(to_delete) == 0:
-        print('No ensembles found to delete in specified range.')
+        print("No ensembles found to delete in specified range.")
         return
 
     _delete_helper(to_delete, yes, dryrun, sanity)
@@ -357,311 +371,324 @@ def download_ensemble(ensemble, out=None, force=False, sanity=False, **args):
 
     if out is None:
         out_file = os.path.abspath(
-            os.path.join(os.getcwd(), '{}.tar.gz'.format(ensemble)))
+            os.path.join(os.getcwd(), "{}.tar.gz".format(ensemble))
+        )
     elif os.path.isdir(out):
-        out_file = os.path.abspath(
-            os.path.join(out, '{}.tar.gz'.format(ensemble)))
+        out_file = os.path.abspath(os.path.join(out, "{}.tar.gz".format(ensemble)))
     else:
         out_file = os.path.abspath(out)
         if not os.path.isdir(os.path.dirname(out_file)):
             os.makedirs(os.path.dirname(out_file))
 
-    if not force and not out_file.endswith('.tar.gz'):
+    if not force and not out_file.endswith(".tar.gz"):
         resp = input(
-            'File {} does not end with .tar.gz. Are you sure you want to continue? (Y/n) '
-            .format(out_file))
-        if resp.lower() != 'y' and resp.lower() != 'yes':
-            print('Not continuing')
+            "File {} does not end with .tar.gz. Are you sure you want to continue? (Y/n) ".format(
+                out_file
+            )
+        )
+        if resp.lower() != "y" and resp.lower() != "yes":
+            print("Not continuing")
             return
 
     if not force and os.path.isfile(out_file):
-        print('File {} already exists. Refusing to overwrite file.'.format(
-            out_file))
+        print("File {} already exists. Refusing to overwrite file.".format(out_file))
         return
 
-    print('Downloading ensemble {} into {}...'.format(ensemble, out_file))
-    with open(out_file, 'wb') as fout:
+    print("Downloading ensemble {} into {}...".format(ensemble, out_file))
+    with open(out_file, "wb") as fout:
         joshua_model.get_ensemble_data(ensemble_id=ensemble, outfile=fout)
-    print('Download completed')
+    print("Download completed")
 
 
 if __name__ == "__main__":
-    name_space = os.environ.get('JOSHUA_NAMESPACE', 'joshua')
-    parser = argparse.ArgumentParser(
-        description='How about a nice game of chess?')
-    parser.add_argument('-C',
-                        '--cluster-file',
-                        '--cluster_file',
-                        dest="cluster_file",
-                        help="Cluster file for Joshua database")
+    name_space = os.environ.get("JOSHUA_NAMESPACE", "joshua")
+    parser = argparse.ArgumentParser(description="How about a nice game of chess?")
     parser.add_argument(
-        '-D',
-        '--dir-path',
-        nargs='+',
+        "-C",
+        "--cluster-file",
+        "--cluster_file",
+        dest="cluster_file",
+        help="Cluster file for Joshua database",
+    )
+    parser.add_argument(
+        "-D",
+        "--dir-path",
+        nargs="+",
         default=(name_space,),
-        help='top-level directory path in which joshua operates')
+        help="top-level directory path in which joshua operates",
+    )
 
-    subparsers = parser.add_subparsers(help='sub-command help')
+    subparsers = parser.add_subparsers(help="sub-command help")
 
-    parser_list = subparsers.add_parser('list', help='list test ensembles')
-    parser_list.add_argument('--stopped',
-                             action='store_true',
-                             help='include stopped ensembles')
-    parser_list.add_argument('--sanity',
-                             action='store_true',
-                             help='list sanity ensembles instead')
-    parser_list.add_argument('--username',
-                             metavar='user',
-                             help='username of user who launched the test',
-                             default=None)
-    parser_list.add_argument('--show-in-progress',
-                             action='store_true',
-                             help='If set, show the progress of currently running tests',
-                             default=None)
+    parser_list = subparsers.add_parser("list", help="list test ensembles")
+    parser_list.add_argument(
+        "--stopped", action="store_true", help="include stopped ensembles"
+    )
+    parser_list.add_argument(
+        "--sanity", action="store_true", help="list sanity ensembles instead"
+    )
+    parser_list.add_argument(
+        "--username",
+        metavar="user",
+        help="username of user who launched the test",
+        default=None,
+    )
+    parser_list.add_argument(
+        "--show-in-progress",
+        action="store_true",
+        help="If set, show the progress of currently running tests",
+        default=None,
+    )
     parser_list.set_defaults(cmd=list_active_ensembles)
 
-    parser_start = subparsers.add_parser('start', help='start a test ensemble')
+    parser_start = subparsers.add_parser("start", help="start a test ensemble")
     parser_start.add_argument(
-        '--tarball',
+        "--tarball",
         required=True,
-        metavar='filename',
-        help='.tar.gz file containing the binaries and data for the test')
-    parser_start.add_argument('--command',
-                              metavar='command',
-                              help='command to execute within the tarball')
-    parser_start.add_argument('--property',
-                              metavar='name=value',
-                              dest='properties',
-                              action='append',
-                              default=[])
-    parser_start.add_argument('--username',
-                              metavar='user',
-                              help='username of user launching the test',
-                              default=get_username())
-    parser_start.add_argument(
-        '--allow-multiple',
-        action='store_true',
-        help='allow previous ensembles launched by this user to keep running')
-    parser_start.add_argument('--not-compressed',
-                              dest='compressed',
-                              action='store_false',
-                              default=True,
-                              help='')
-    parser_start.add_argument(
-        '--sanity',
-        action='store_true',
-        help=
-        'mark this ensemble as a sanity test (i.e., joshua exits if this test fails'
+        metavar="filename",
+        help=".tar.gz file containing the binaries and data for the test",
     )
     parser_start.add_argument(
-        '--timeout',
-        metavar='timeout',
+        "--command", metavar="command", help="command to execute within the tarball"
+    )
+    parser_start.add_argument(
+        "--property",
+        metavar="name=value",
+        dest="properties",
+        action="append",
+        default=[],
+    )
+    parser_start.add_argument(
+        "--username",
+        metavar="user",
+        help="username of user launching the test",
+        default=get_username(),
+    )
+    parser_start.add_argument(
+        "--allow-multiple",
+        action="store_true",
+        help="allow previous ensembles launched by this user to keep running",
+    )
+    parser_start.add_argument(
+        "--not-compressed",
+        dest="compressed",
+        action="store_false",
+        default=True,
+        help="",
+    )
+    parser_start.add_argument(
+        "--sanity",
+        action="store_true",
+        help="mark this ensemble as a sanity test (i.e., joshua exits if this test fails",
+    )
+    parser_start.add_argument(
+        "--timeout",
+        metavar="timeout",
         type=int,
         default=5400,
-        help=
-        'number of seconds to wait before killing an ensemble (default is 5400 s)'
+        help="number of seconds to wait before killing an ensemble (default is 5400 s)",
     )
     parser_start.add_argument(
-        '--no-timeout',
-        action='store_true',
-        help='indicate that this test should be run without any kind of timeout'
+        "--no-timeout",
+        action="store_true",
+        help="indicate that this test should be run without any kind of timeout",
     )
     parser_start.add_argument(
-        '-F',
-        '--fail-fast',
+        "-F",
+        "--fail-fast",
         required=False,
         type=int,
-        metavar='FAILURES',
+        metavar="FAILURES",
         default=10,
-        help='number of failures after to which to terminate the job')
-    parser_start.add_argument(
-        '--no-fail-fast',
-        action='store_true',
-        help=
-        'do not limit the number of failures for this ensemble (causes --fail-fast to be ignored)'
+        help="number of failures after to which to terminate the job",
     )
     parser_start.add_argument(
-        '--max-runs',
+        "--no-fail-fast",
+        action="store_true",
+        help="do not limit the number of failures for this ensemble (causes --fail-fast to be ignored)",
+    )
+    parser_start.add_argument(
+        "--max-runs",
         required=False,
         type=int,
-        metavar='MAX_RUNS',
+        metavar="MAX_RUNS",
         default=100000,
-        help='maximum number of runs after which to terminate the job')
+        help="maximum number of runs after which to terminate the job",
+    )
     parser_start.add_argument(
-        '--no-max-runs',
-        action='store_true',
-        help='do not limit the number of runs of this job')
+        "--no-max-runs",
+        action="store_true",
+        help="do not limit the number of runs of this job",
+    )
     parser_start.add_argument(
-        '--priority',
+        "--priority",
         required=False,
         type=int,
-        metavar='PRIORITY',
+        metavar="PRIORITY",
         default=100,
-        help='percent adjustment of CPU time allocated to this job')
+        help="percent adjustment of CPU time allocated to this job",
+    )
     parser_start.add_argument(
-        '--env',
-        metavar='name=value',
-        dest='env',
-        action='append',
+        "--env",
+        metavar="name=value",
+        dest="env",
+        action="append",
         default=[],
-        help="environment variable to add to the job's execution")
+        help="environment variable to add to the job's execution",
+    )
     parser_start.set_defaults(cmd=start_ensemble)
 
-    parser_stop = subparsers.add_parser('stop', help='stop a test ensemble')
-    parser_stop.add_argument('--id',
-                             dest='ensemble',
-                             help='stop the given ensemble by ID')
-    parser_stop.add_argument('--username',
-                             metavar='user',
-                             help='stop all ensembles with the given username')
-    parser_stop.add_argument('--sanity',
-                             action='store_true',
-                             help='stop only sanity ensembles')
+    parser_stop = subparsers.add_parser("stop", help="stop a test ensemble")
+    parser_stop.add_argument(
+        "--id", dest="ensemble", help="stop the given ensemble by ID"
+    )
+    parser_stop.add_argument(
+        "--username", metavar="user", help="stop all ensembles with the given username"
+    )
+    parser_stop.add_argument(
+        "--sanity", action="store_true", help="stop only sanity ensembles"
+    )
     parser_stop.set_defaults(cmd=stop_ensemble)
 
-    parser_resume = subparsers.add_parser('resume',
-                                          help='resume a stopped test ensemble')
-    parser_resume.add_argument('ensemble',
-                               nargs='?',
-                               metavar='id',
-                               help='ensemble to resume')
-    parser_resume.add_argument('--sanity',
-                               action='store_true',
-                               help='ensemble to resume is a sanity ensemble')
+    parser_resume = subparsers.add_parser(
+        "resume", help="resume a stopped test ensemble"
+    )
+    parser_resume.add_argument(
+        "ensemble", nargs="?", metavar="id", help="ensemble to resume"
+    )
+    parser_resume.add_argument(
+        "--sanity", action="store_true", help="ensemble to resume is a sanity ensemble"
+    )
     parser_resume.set_defaults(cmd=resume_ensemble)
 
-    parser_tail = subparsers.add_parser('tail', help='tail test results')
-    parser_tail.add_argument('ensemble',
-                             nargs='?',
-                             metavar='id',
-                             help='ensemble to get results from')
-    parser_tail.add_argument('--username',
-                             metavar='user',
-                             help='username of user launching the test')
-    parser_tail.add_argument('--raw',
-                             action='store_true',
-                             help='Test output only')
-    parser_tail.add_argument('--errors',
-                             dest="errors_only",
-                             action='store_true',
-                             help='Errors only')
-    parser_tail.add_argument('--xml',
-                             dest="xml",
-                             action='store_true',
-                             help='wrap raw output in <Trace> tags')
-    parser_tail.add_argument('--simple',
-                             dest="simple",
-                             action='store_true',
-                             help='display simple raw output in <Trace> tags')
-    parser_tail.add_argument('--sanity',
-                             action='store_true',
-                             help='get output from sanity ensembles')
+    parser_tail = subparsers.add_parser("tail", help="tail test results")
+    parser_tail.add_argument(
+        "ensemble", nargs="?", metavar="id", help="ensemble to get results from"
+    )
+    parser_tail.add_argument(
+        "--username", metavar="user", help="username of user launching the test"
+    )
+    parser_tail.add_argument("--raw", action="store_true", help="Test output only")
+    parser_tail.add_argument(
+        "--errors", dest="errors_only", action="store_true", help="Errors only"
+    )
+    parser_tail.add_argument(
+        "--xml", dest="xml", action="store_true", help="wrap raw output in <Trace> tags"
+    )
+    parser_tail.add_argument(
+        "--simple",
+        dest="simple",
+        action="store_true",
+        help="display simple raw output in <Trace> tags",
+    )
+    parser_tail.add_argument(
+        "--sanity", action="store_true", help="get output from sanity ensembles"
+    )
     parser_tail.set_defaults(cmd=tail_ensemble)
 
-    parser_failures = subparsers.add_parser('failures',
-                                            help='list agent failures')
+    parser_failures = subparsers.add_parser("failures", help="list agent failures")
     parser_failures.add_argument(
-        '--start',
+        "--start",
         default=None,
-        help=
-        'start date time (in most standard date formats) for failures to report, the default of which is one week ago'
+        help="start date time (in most standard date formats) for failures to report, the default of which is one week ago",
     )
     parser_failures.add_argument(
-        '--end',
+        "--end",
         default=None,
-        help=
-        'end date time for failures to report, the default of which is no limit'
+        help="end date time for failures to report, the default of which is no limit",
     )
     parser_failures.set_defaults(cmd=agent_failures)
 
-    parser_delete = subparsers.add_parser('delete', help='delete old runs')
-    parser_delete.add_argument('ensembles',
-                               nargs='+',
-                               metavar='id',
-                               help='ensembles to delete')
-    parser_delete.add_argument('-y',
-                               '--yes',
-                               action='store_true',
-                               default=False,
-                               help='don\'t prompt the user before deleting')
+    parser_delete = subparsers.add_parser("delete", help="delete old runs")
     parser_delete.add_argument(
-        '--dryrun',
-        action='store_true',
-        default=False,
-        help=
-        'don\'t actually delete (just list what would be deleted); this overrides the -y flag'
+        "ensembles", nargs="+", metavar="id", help="ensembles to delete"
     )
     parser_delete.add_argument(
-        '--sanity',
+        "-y",
+        "--yes",
+        action="store_true",
         default=False,
-        action='store_true',
-        help='delete sanity tests along with regular ensembles')
+        help="don't prompt the user before deleting",
+    )
+    parser_delete.add_argument(
+        "--dryrun",
+        action="store_true",
+        default=False,
+        help="don't actually delete (just list what would be deleted); this overrides the -y flag",
+    )
+    parser_delete.add_argument(
+        "--sanity",
+        default=False,
+        action="store_true",
+        help="delete sanity tests along with regular ensembles",
+    )
     parser_delete.set_defaults(cmd=delete_ensembles)
 
-    parser_delete_range = subparsers.add_parser('deleterange',
-                                                help='delete range of old runs')
+    parser_delete_range = subparsers.add_parser(
+        "deleterange", help="delete range of old runs"
+    )
     parser_delete_range.add_argument(
-        '--before',
+        "--before",
         default=None,
-        help=
-        'latest date time (in most standard date formats) for results to be deleted; this endpoint is exclusive'
+        help="latest date time (in most standard date formats) for results to be deleted; this endpoint is exclusive",
     )
     parser_delete_range.add_argument(
-        '--after',
+        "--after",
         default=None,
-        help=
-        'earliest date time (in most standard date formats) for results to be deleted; this endpoint is exclusive'
+        help="earliest date time (in most standard date formats) for results to be deleted; this endpoint is exclusive",
     )
     parser_delete_range.add_argument(
-        '-y',
-        '--yes',
-        action='store_true',
+        "-y",
+        "--yes",
+        action="store_true",
         default=False,
-        help='don\'t prompt the user before deleting')
-    parser_delete_range.add_argument(
-        '--dryrun',
-        action='store_true',
-        default=False,
-        help=
-        'don\'t actually delete (just list what would be deleted); this overrides the -y flag'
+        help="don't prompt the user before deleting",
     )
     parser_delete_range.add_argument(
-        '--sanity',
+        "--dryrun",
+        action="store_true",
         default=False,
-        action='store_true',
-        help='delete sanity tests along with regular ensembles')
+        help="don't actually delete (just list what would be deleted); this overrides the -y flag",
+    )
+    parser_delete_range.add_argument(
+        "--sanity",
+        default=False,
+        action="store_true",
+        help="delete sanity tests along with regular ensembles",
+    )
     parser_delete_range.set_defaults(cmd=delete_ensemble_range)
 
     parser_download = subparsers.add_parser(
-        'download', help='download the ensemble for a given run')
-    parser_download.add_argument('ensemble',
-                                 nargs='?',
-                                 metavar='id',
-                                 help='ensemble to download')
-    parser_download.add_argument(
-        '-o',
-        '--out',
-        default=None,
-        help=
-        'file or directory to write ensemble tar.gz file to (default is current working directory with ensemble name)'
+        "download", help="download the ensemble for a given run"
     )
     parser_download.add_argument(
-        '-f',
-        '--force',
-        default=False,
-        action='store_true',
-        help='overwrite existing files and directories when downloading')
+        "ensemble", nargs="?", metavar="id", help="ensemble to download"
+    )
     parser_download.add_argument(
-        '--sanity',
+        "-o",
+        "--out",
+        default=None,
+        help="file or directory to write ensemble tar.gz file to (default is current working directory with ensemble name)",
+    )
+    parser_download.add_argument(
+        "-f",
+        "--force",
         default=False,
-        action='store_true',
-        help='ensemble in question is a sanity ensemble')
+        action="store_true",
+        help="overwrite existing files and directories when downloading",
+    )
+    parser_download.add_argument(
+        "--sanity",
+        default=False,
+        action="store_true",
+        help="ensemble in question is a sanity ensemble",
+    )
     parser_download.set_defaults(cmd=download_ensemble)
 
     arguments = parser.parse_args()
     joshua_model.open(arguments.cluster_file, dir_path=arguments.dir_path)
 
-    if 'cmd' not in arguments:
+    if "cmd" not in arguments:
         parser.print_usage()
         exit(-1)
 

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -18,13 +18,25 @@
 # limitations under the License.
 #
 
-from typing import Dict, Tuple
-from . import joshua_model, process_handling
-import argparse, errno, os, random, shutil, re, sys, tarfile, traceback, tempfile, time
+import argparse
+import errno
+import os
+import queue
+import random
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+import traceback
+import datetime
+
 import subprocess32 as subprocess
-import threading, queue
 import fdb
-from datetime import datetime, timezone
+from . import joshua_model
+from . import process_handling
 
 try:
     import childsubreaper
@@ -482,7 +494,7 @@ class AsyncEnsemble:
                 getFileHandle().write(".")
 
         duration = max(1, time.time() - start_time)
-        done_timestamp = joshua_model.format_datetime(datetime.now(timezone.utc))
+        done_timestamp = joshua_model.format_datetime(datetime.datetime.now(datetime.timezone.utc))
 
         if retcode == -2 and time.time() > timeout_time:
             if os.path.isfile(os.path.join(where, timeout_command)):

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -1,6 +1,6 @@
-#
-# joshua_model.py
-#
+"""
+    joshua_model.py
+"""
 # This source file is part of the FoundationDB open source project
 #
 # Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
@@ -22,6 +22,7 @@ from collections import defaultdict
 
 from typing import Dict, Tuple, List, Optional
 import fdb
+
 fdb.api_version(520)
 import fdb.tuple
 from io import BytesIO
@@ -51,10 +52,11 @@ ONE = b"\x01" + b"\x00" * 7
 TIMESTAMP_FMT = "%Y%m%d-%H%M%S"
 
 TIMEDELTA_REGEX1 = re.compile(
-    r'(?P<days>[-\d]+) day[s]*, (?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d[\.\d+]*)'
+    r"(?P<days>[-\d]+) day[s]*, (?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d[\.\d+]*)"
 )
 TIMEDELTA_REGEX2 = re.compile(
-    r'(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d[\.\d+]*)')
+    r"(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d[\.\d+]*)"
+)
 
 # A random instance ID as the seed for Joshua agent
 instanceid = os.urandom(8)
@@ -62,9 +64,9 @@ instanceid = os.urandom(8)
 BLOB_KEY_LIMIT = 8192
 BLOB_TRANSACTION_LIMIT = 128 * 1024
 
-INSTANCE_ID_ENV_VAR = 'PLATFORM_SHORT_INSTANCE_ID'
-OLD_INSTANCE_ID_ENV_VAR = 'SHORT_TASK_ID'
-HOSTNAME_ENV_VAR = 'HOSTNAME'
+INSTANCE_ID_ENV_VAR = "PLATFORM_SHORT_INSTANCE_ID"
+OLD_INSTANCE_ID_ENV_VAR = "SHORT_TASK_ID"
+HOSTNAME_ENV_VAR = "HOSTNAME"
 
 db = None
 dir_top = None
@@ -99,8 +101,7 @@ def open(cluster_file=None, dir_path=("joshua",)):
     dir_ensemble_results = dir_ensembles.create_or_open(db, "results")
     dir_ensemble_results_pass = dir_ensemble_results.create_or_open(db, "pass")
     dir_ensemble_results_fail = dir_ensemble_results.create_or_open(db, "fail")
-    dir_ensemble_results_large = dir_ensemble_results.create_or_open(
-        db, "large")
+    dir_ensemble_results_large = dir_ensemble_results.create_or_open(db, "large")
     dir_failures = dir_top.create_or_open(db, "failures")
 
     dir_active_changes = dir_active
@@ -141,19 +142,16 @@ def transactional(func):
 
 
 def wrap_error(description):
-    root = ET.Element('Test')
-    ET.SubElement(root, 'JoshuaError', {
-        'Severity': '40',
-        'ErrorMessage': description
-    })
+    root = ET.Element("Test")
+    ET.SubElement(root, "JoshuaError", {"Severity": "40", "ErrorMessage": description})
     return ET.tostring(root)
 
 
 def wrap_message(info={}):
-    root = ET.Element('Test')
-    attribs = {'Severity': '10'}
+    root = ET.Element("Test")
+    attribs = {"Severity": "10"}
     attribs.update(info)
-    ET.SubElement(root, 'JoshuaMessage', attribs)
+    ET.SubElement(root, "JoshuaMessage", attribs)
     return ET.tostring(root)
 
 
@@ -170,7 +168,7 @@ def get_hostname():
 
 def is_message(text):
     # Hmm...perhaps this could be better.
-    return text.startswith('<Test><JoshuaMessage')
+    return text.startswith("<Test><JoshuaMessage")
 
 
 def unwrap_message(text):
@@ -184,7 +182,7 @@ def load_datetime(string):
 
 
 def load_timedelta(string):
-    if 'day' in string:
+    if "day" in string:
         m = TIMEDELTA_REGEX1.match(string)
     else:
         m = TIMEDELTA_REGEX2.match(string)
@@ -194,17 +192,17 @@ def load_timedelta(string):
 
 
 def format_timedelta(timedelta_obj):
-    return str(timedelta_obj).split('.', 2)[0]
+    return str(timedelta_obj).split(".", 2)[0]
 
 
 def format_datetime(dt_obj):
     return dt_obj.strftime(TIMESTAMP_FMT)
 
 
-def _list_and_watch_ensembles(tr : fdb.Transaction, dir, changes):
+def _list_and_watch_ensembles(tr: fdb.Transaction, dir, changes):
     ensembles = []
     for k, v in tr[dir.range()]:
-        ensemble, = dir.unpack(k)
+        (ensemble,) = dir.unpack(k)
         ensembles.append(ensemble)
 
     return ensembles, tr.watch(changes.key())
@@ -212,8 +210,7 @@ def _list_and_watch_ensembles(tr : fdb.Transaction, dir, changes):
 
 @transactional
 def identify_existing_ensembles(tr, ensembles):
-    return list(
-        filter(lambda eid: tr[dir_all_ensembles[eid]] != None, ensembles))
+    return list(filter(lambda eid: tr[dir_all_ensembles[eid]] != None, ensembles))
 
 
 @transactional
@@ -245,22 +242,25 @@ def get_ensemble_properties(tr, ensemble, snapshot=False):
 
 def _unpack_property(ensemble, key, value, into):
     t = dir_all_ensembles[ensemble].unpack(key)
-    if t[0] == 'properties':
+    if t[0] == "properties":
         into[t[1]] = fdb.tuple.unpack(value)[0]
-    elif t[0] == 'count':
+    elif t[0] == "count":
         into[t[1]] = struct.unpack("<Q", value)[0]
 
 
 def _list_ensembles(tr, dir) -> List[Tuple[str, Dict]]:
     prop_reads = []
     for k, v in tr[dir.range()]:
-        ensemble, = dir.unpack(k)
+        (ensemble,) = dir.unpack(k)
         r = dir_all_ensembles[ensemble].range()
         prop_reads.append(
-            (ensemble,
-             tr.get_range(r.start,
-                          r.stop,
-                          streaming_mode=fdb.StreamingMode.want_all)))
+            (
+                ensemble,
+                tr.get_range(
+                    r.start, r.stop, streaming_mode=fdb.StreamingMode.want_all
+                ),
+            )
+        )
     ensembles = []
     for ensemble, prop_kvs in prop_reads:
         props = {}
@@ -281,17 +281,17 @@ def list_sanity_ensembles(tr) -> List[Tuple[str, Dict]]:
 
 
 def list_all_ensembles() -> List[Tuple[str, Dict]]:
-    ensembles : List[Tuple[str, Dict]]= []
+    ensembles: List[Tuple[str, Dict]] = []
     r = dir_all_ensembles.range()
     start = r.start
     tr = db.create_transaction()
     while True:
         prev_start = start
         try:
-            for k, v in tr.get_range(start,
-                                     r.stop,
-                                     streaming_mode=fdb.StreamingMode.want_all):
-                start = k + b'\x00'
+            for k, v in tr.get_range(
+                start, r.stop, streaming_mode=fdb.StreamingMode.want_all
+            ):
+                start = k + b"\x00"
                 t = dir_all_ensembles.unpack(k)
                 if len(t) == 1:
                     ensembles.append((t[0], {}))
@@ -314,8 +314,8 @@ def get_ensemble_mean_durations(tr, ensembles=None):
 
     duration_map = {}
     for ensemble in ensembles:
-        duration = _get_snap_counter(tr, ensemble, 'duration')
-        ended = _get_snap_counter(tr, ensemble, 'ended')
+        duration = _get_snap_counter(tr, ensemble, "duration")
+        ended = _get_snap_counter(tr, ensemble, "ended")
 
         if ended == 0:
             duration_map[ensemble] = 1.0
@@ -332,7 +332,7 @@ def get_ensemble_priorities(tr, ensembles=None):
 
     priority_map = {}
     for ensemble in ensembles:
-        priority = _get_snap_counter(tr, ensemble, 'priority')
+        priority = _get_snap_counter(tr, ensemble, "priority")
         if priority == 0:
             priority = 100
         priority_map[ensemble] = priority / float(100)
@@ -342,10 +342,8 @@ def get_ensemble_priorities(tr, ensembles=None):
 
 @fdb.transactional
 def _insert_blobpart(tr, subspace, offset, data):
-    for rel_offs in range(0, min(BLOB_TRANSACTION_LIMIT, len(data)),
-                          BLOB_KEY_LIMIT):
-        tr[subspace[offset + rel_offs]] = data[rel_offs:rel_offs +
-                                               BLOB_KEY_LIMIT]
+    for rel_offs in range(0, min(BLOB_TRANSACTION_LIMIT, len(data)), BLOB_KEY_LIMIT):
+        tr[subspace[offset + rel_offs]] = data[rel_offs : rel_offs + BLOB_KEY_LIMIT]
 
 
 def _insert_blob(db, subspace, file, offset=0, verbose=False):
@@ -367,14 +365,14 @@ def _insert_blob(db, subspace, file, offset=0, verbose=False):
 @fdb.transactional
 def _read_blobpart(tr, subspace, offset):
     data = []
-    for k, v in tr[subspace[offset]:subspace[offset + BLOB_TRANSACTION_LIMIT]]:
-        #print( len(data), offset, len(v), repr(k), repr(subspace[offset].key()) )
+    for k, v in tr[subspace[offset] : subspace[offset + BLOB_TRANSACTION_LIMIT]]:
+        # print( len(data), offset, len(v), repr(k), repr(subspace[offset].key()) )
         assert subspace[offset].key() == k
         data.append(v)
         offset += len(v)
         if not v:
             break
-    return b''.join(data)
+    return b"".join(data)
 
 
 def _read_blob(db, subspace, file):
@@ -397,12 +395,11 @@ def _create_ensemble(tr, ensemble_id, properties, sanity=False):
     dir, changes = get_dir_changes(sanity)
 
     if tr[dir_all_ensembles[ensemble_id]] != None:
-        print('{} already inserted'.format(ensemble_id))
+        print("{} already inserted".format(ensemble_id))
         return  # Already inserted
     tr[dir_all_ensembles[ensemble_id]] = b""
     for k, v in properties.items():
-        tr[dir_all_ensembles[ensemble_id]['properties'][k]] = fdb.tuple.pack(
-            (v,))
+        tr[dir_all_ensembles[ensemble_id]["properties"][k]] = fdb.tuple.pack((v,))
     tr[dir[ensemble_id]] = b""
     tr.add(changes, ONE)
 
@@ -411,26 +408,30 @@ def create_ensemble(userid, properties, tarball, sanity=False):
     hash = get_hash(tarball)
     timestamp = format_datetime(datetime.now(timezone.utc))
     ensemble_id = timestamp + "-" + userid + "-" + hash[:16]
-    if 'submitted' not in properties:
-        properties['submitted'] = timestamp
+    if "submitted" not in properties:
+        properties["submitted"] = timestamp
     _insert_blob(db, dir_ensemble_data[ensemble_id], tarball, 0, True)
     _create_ensemble(db, ensemble_id, properties, sanity)
-    logger.debug('created ensemble {}, properties: {}, sanity: {}'.format(
-        ensemble_id, properties, sanity))
+    logger.debug(
+        "created ensemble {}, properties: {}, sanity: {}".format(
+            ensemble_id, properties, sanity
+        )
+    )
     return ensemble_id
 
 
 def stop_user_ensembles(username, sanity=False):
     if not username:
-        raise Exception(
-            "Unable to stop ensembles belonging to unspecified user.")
+        raise Exception("Unable to stop ensembles belonging to unspecified user.")
     ensemble_list = get_active_ensembles(False, sanity, username)
     for e, props in ensemble_list:
         if "-" + username + "-" in str(e):
             stop_ensemble(e, sanity)
 
 
-def get_active_ensembles(stopped, sanity=False, username=None) -> List[Tuple[str, Dict]]:
+def get_active_ensembles(
+    stopped, sanity=False, username=None
+) -> List[Tuple[str, Dict]]:
     if stopped:
         ensemble_list = list_all_ensembles()
     elif sanity:
@@ -440,34 +441,36 @@ def get_active_ensembles(stopped, sanity=False, username=None) -> List[Tuple[str
     # Filter by username, if specified
     if username:
         ensemble_list = list(
-            filter(lambda i: i[1].get('username', None) == username,
-                   ensemble_list))
+            filter(lambda i: i[1].get("username", None) == username, ensemble_list)
+        )
     # Determine the runtime, if not defined
     for e, props in ensemble_list:
-        if props.get('runtime', None) is None:
-            if props.get('submitted', None) is not None:
-                props['runtime'] = format_timedelta(
-                    datetime.now(timezone.utc) -
-                    load_datetime(props['submitted']))
-        if props.get('stopped', None) is not None:
-            props['remaining'] = "0"
-        elif props.get('runtime', None) is not None:
-            if props.get('ended', None) is not None:
-                jobs_done = int(props.get('ended', 1))
-                if props.get('max_runs', None) is None:
-                    props['remaining'] = "no_max"
-                elif int(props.get('max_runs', 0)) < jobs_done:
-                    props['remaining'] = "stopping"
+        if props.get("runtime", None) is None:
+            if props.get("submitted", None) is not None:
+                props["runtime"] = format_timedelta(
+                    datetime.now(timezone.utc) - load_datetime(props["submitted"])
+                )
+        if props.get("stopped", None) is not None:
+            props["remaining"] = "0"
+        elif props.get("runtime", None) is not None:
+            if props.get("ended", None) is not None:
+                jobs_done = int(props.get("ended", 1))
+                if props.get("max_runs", None) is None:
+                    props["remaining"] = "no_max"
+                elif int(props.get("max_runs", 0)) < jobs_done:
+                    props["remaining"] = "stopping"
                 else:
-                    props['remaining'] = format_timedelta(
+                    props["remaining"] = format_timedelta(
                         datetime.timedelta(
-                            seconds=load_timedelta(
-                                props['runtime']).total_seconds() *
-                            (int(props['max_runs']) - jobs_done) / jobs_done))
+                            seconds=load_timedelta(props["runtime"]).total_seconds()
+                            * (int(props["max_runs"]) - jobs_done)
+                            / jobs_done
+                        )
+                    )
             else:
-                props['remaining'] = "not_started"
+                props["remaining"] = "not_started"
         else:
-            props['remaining'] = "old_version"
+            props["remaining"] = "old_version"
     return ensemble_list
 
 
@@ -486,18 +489,24 @@ def _stop_ensemble(tr, ensemble_id, sanity=False):
         # Get the ensemble properties
         properties = get_ensemble_properties(ensemble_id)
         # Get the ensemble submission time, if not defined use now
-        submitted = load_datetime(
-            fdb.tuple.unpack(
-                tr[dir_all_ensembles[ensemble_id]['properties']['submitted']])
-            [0]) if 'submitted' in properties else stoptime
+        submitted = (
+            load_datetime(
+                fdb.tuple.unpack(
+                    tr[dir_all_ensembles[ensemble_id]["properties"]["submitted"]]
+                )[0]
+            )
+            if "submitted" in properties
+            else stoptime
+        )
 
         # Set the stoptime of the ensemble
-        tr[dir_all_ensembles[ensemble_id]['properties']
-           ['stopped']] = fdb.tuple.pack((format_datetime(stoptime),))
+        tr[dir_all_ensembles[ensemble_id]["properties"]["stopped"]] = fdb.tuple.pack(
+            (format_datetime(stoptime),)
+        )
         # Set the runtime of the ensemble
-        tr[dir_all_ensembles[ensemble_id]['properties']
-           ['runtime']] = fdb.tuple.pack(
-               (format_timedelta(stoptime - submitted),))
+        tr[dir_all_ensembles[ensemble_id]["properties"]["runtime"]] = fdb.tuple.pack(
+            (format_timedelta(stoptime - submitted),)
+        )
 
     del tr[dir[ensemble_id]]
     tr.add(changes, ONE)
@@ -528,7 +537,7 @@ def _delete_ensemble_data(tr, ensemble_id, sanity=False):
 
     # Only delete if present.
     if tr[dir_all_ensembles[ensemble_id]] == None:
-        print('Ensemble', ensemble_id, 'already deleted.')
+        print("Ensemble", ensemble_id, "already deleted.")
         return
 
     # Remove results stored using BlobVersion = 2.
@@ -553,7 +562,7 @@ def _delete_ensemble_data(tr, ensemble_id, sanity=False):
 def delete_ensemble(ensemble_id, compressed=True, sanity=False):
     # Only delete if present.
     if db[dir_all_ensembles[ensemble_id]] == None:
-        print('Ensemble', ensemble_id, 'already deleted.')
+        print("Ensemble", ensemble_id, "already deleted.")
         return
     _delete_ensemble_data(ensemble_id, sanity)
 
@@ -567,38 +576,44 @@ def get_ensemble_data(ensemble_id, outfile=None):
 
 def set_versionstamped_key(tr, prefix, suffix, value):
     tr.set_versionstamped_key(
-        prefix + b"\x1d\x0b\x01" + b"." * 10 + suffix +
-        struct.pack("<I",
-                    len(prefix) + 3), value)
+        prefix
+        + b"\x1d\x0b\x01"
+        + b"." * 10
+        + suffix
+        + struct.pack("<I", len(prefix) + 3),
+        value,
+    )
 
 
-def _increment(tr : fdb.Transaction, ensemble_id : str, counter : str) -> None:
-    tr.add(dir_all_ensembles[ensemble_id]['count'][counter], ONE)
+def _increment(tr: fdb.Transaction, ensemble_id: str, counter: str) -> None:
+    tr.add(dir_all_ensembles[ensemble_id]["count"][counter], ONE)
 
 
-def _add(tr : fdb.Transaction, ensemble_id : str, counter : str, value : int) -> None:
+def _add(tr: fdb.Transaction, ensemble_id: str, counter: str, value: int) -> None:
     byte_val = struct.pack("<Q", value)
-    tr.add(dir_all_ensembles[ensemble_id]['count'][counter], byte_val)
+    tr.add(dir_all_ensembles[ensemble_id]["count"][counter], byte_val)
 
 
-def _get_snap_counter(tr : fdb.Transaction, ensemble_id : str, counter : str) -> int:
-    value = tr.snapshot.get(dir_all_ensembles[ensemble_id]['count'][counter])
+def _get_snap_counter(tr: fdb.Transaction, ensemble_id: str, counter: str) -> int:
+    value = tr.snapshot.get(dir_all_ensembles[ensemble_id]["count"][counter])
     if value == None:
         return 0
     else:
-        return struct.unpack("<Q", b'' + value)[0]
+        return struct.unpack("<Q", b"" + value)[0]
 
 
-def _get_seeds_and_heartbeats(ensemble_id : str, tr : fdb.Transaction) -> List[Tuple[int, float]]:
+def _get_seeds_and_heartbeats(
+    ensemble_id: str, tr: fdb.Transaction
+) -> List[Tuple[int, float]]:
     result = []
     for k, v in tr.snapshot[dir_ensemble_incomplete[ensemble_id]["heartbeat"].range()]:
-        seed, = dir_ensemble_incomplete[ensemble_id]["heartbeat"].unpack(k)
-        heartbeat, = fdb.tuple.unpack(v)
+        (seed,) = dir_ensemble_incomplete[ensemble_id]["heartbeat"].unpack(k)
+        (heartbeat,) = fdb.tuple.unpack(v)
         result.append((seed, heartbeat))
     return result
 
 
-def _get_hostname(ensemble_id : str, seed : int, tr : fdb.Transaction) -> Optional[str]:
+def _get_hostname(ensemble_id: str, seed: int, tr: fdb.Transaction) -> Optional[str]:
     v = tr.snapshot[dir_ensemble_incomplete[ensemble_id][seed]["hostname"]]
     if v != None:
         return fdb.tuple.unpack(v)[0]
@@ -606,7 +621,7 @@ def _get_hostname(ensemble_id : str, seed : int, tr : fdb.Transaction) -> Option
 
 
 @transactional
-def should_run_ensemble(tr : fdb.Transaction, ensemble_id : str) -> bool:
+def should_run_ensemble(tr: fdb.Transaction, ensemble_id: str) -> bool:
     """
     Return True if this agent should start a run for this ensemble. The
     policy tries not to overshoot max_runs by too much, but also accounts
@@ -629,12 +644,17 @@ def should_run_ensemble(tr : fdb.Transaction, ensemble_id : str) -> bool:
             # No other agents are running a test for this ensemble (is this possible?)
             return True
         if max_heartbeat_age > 10:
-            print("Agent {} presumed dead. Attempting to steal its work.".format(
-                _get_hostname(ensemble_id, max_seed, tr)))
+            print(
+                "Agent {} presumed dead. Attempting to steal its work.".format(
+                    _get_hostname(ensemble_id, max_seed, tr)
+                )
+            )
 
             # If we read at snapshot isolation then an arbitrary number of agents could steal this run/seed.
             # We only want one agent to succeed in taking over for the dead agent's run/seed.
-            tr.add_read_conflict_key(dir_ensemble_incomplete[ensemble_id]["heartbeat"][max_seed])
+            tr.add_read_conflict_key(
+                dir_ensemble_incomplete[ensemble_id]["heartbeat"][max_seed]
+            )
             del tr[dir_ensemble_incomplete[ensemble_id][max_seed].range()]
             del tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][max_seed]]
             return True
@@ -645,7 +665,7 @@ def should_run_ensemble(tr : fdb.Transaction, ensemble_id : str) -> bool:
 
 
 @transactional
-def show_in_progress(tr : fdb.Transaction, ensemble_id : str) -> List[Tuple[int, Dict]]:
+def show_in_progress(tr: fdb.Transaction, ensemble_id: str) -> List[Tuple[int, Dict]]:
     """
     Returns a list of properties for in progress tests
     """
@@ -677,35 +697,47 @@ def try_starting_test(tr, ensemble_id, seed, sanity=False) -> bool:
         # Don't run the same seed twice simultaneously
         return tr[dir_ensemble_incomplete[ensemble_id][seed]] == instanceid
 
-    _increment(tr, ensemble_id, 'started')
+    _increment(tr, ensemble_id, "started")
     tr[dir_ensemble_incomplete[ensemble_id][seed]] = instanceid
     current_time = time.time()
-    tr[dir_ensemble_incomplete[ensemble_id][seed]["began_at"]] = fdb.tuple.pack((current_time,))
-    tr[dir_ensemble_incomplete[ensemble_id][seed]["hostname"]] = fdb.tuple.pack((get_hostname(),))
-    tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][seed]] = fdb.tuple.pack((current_time,))
+    tr[dir_ensemble_incomplete[ensemble_id][seed]["began_at"]] = fdb.tuple.pack(
+        (current_time,)
+    )
+    tr[dir_ensemble_incomplete[ensemble_id][seed]["hostname"]] = fdb.tuple.pack(
+        (get_hostname(),)
+    )
+    tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][seed]] = fdb.tuple.pack(
+        (current_time,)
+    )
     return True
 
 
 @transactional
 def heartbeat_and_check_running(tr, ensemble_id, seed, sanity=False):
     dir, _ = get_dir_changes(sanity)
-    result = tr[dir[ensemble_id]] != None and tr[
-        dir_ensemble_incomplete[ensemble_id][seed]] == instanceid
+    result = (
+        tr[dir[ensemble_id]] != None
+        and tr[dir_ensemble_incomplete[ensemble_id][seed]] == instanceid
+    )
     if result:
-        tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][seed]] = fdb.tuple.pack((time.time(),))
+        tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][seed]] = fdb.tuple.pack(
+            (time.time(),)
+        )
     return result
 
 
 @transactional
-def _insert_results(tr,
-                    ensemble_id,
-                    seed,
-                    result_code,
-                    output,
-                    sanity=False,
-                    fail_fast=0,
-                    max_runs=0,
-                    duration=0):
+def _insert_results(
+    tr,
+    ensemble_id,
+    seed,
+    result_code,
+    output,
+    sanity=False,
+    fail_fast=0,
+    max_runs=0,
+    duration=0,
+):
     dir, _ = get_dir_changes(sanity)
 
     if tr[dir[ensemble_id]] == None:
@@ -718,46 +750,51 @@ def _insert_results(tr,
     del tr[dir_ensemble_incomplete[ensemble_id][seed].range()]
     del tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][seed]]
 
-    _increment(tr, ensemble_id, 'ended')
+    _increment(tr, ensemble_id, "ended")
 
     if result_code:
-        _increment(tr, ensemble_id, 'fail')
+        _increment(tr, ensemble_id, "fail")
         results = dir_ensemble_results_fail
 
         if fail_fast > 0:
             # This is a snapshot read so that two insertions don't conflict.
-            failures = _get_snap_counter(tr, ensemble_id, 'fail')
+            failures = _get_snap_counter(tr, ensemble_id, "fail")
             if failures >= fail_fast:
                 _stop_ensemble(tr, ensemble_id, sanity)
 
     else:
-        _increment(tr, ensemble_id, 'pass')
+        _increment(tr, ensemble_id, "pass")
         results = dir_ensemble_results_pass
 
     if max_runs > 0:
         # This is a snapshot read so that two insertions don't conflict.
-        ended = _get_snap_counter(tr, ensemble_id, 'ended')
+        ended = _get_snap_counter(tr, ensemble_id, "ended")
         if ended >= max_runs:
             _stop_ensemble(tr, ensemble_id, sanity)
 
     if duration:
-        _add(tr, ensemble_id, 'duration', int(duration))
+        _add(tr, ensemble_id, "duration", int(duration))
 
-    set_versionstamped_key(tr, results[ensemble_id].key(),
-                           fdb.tuple.pack((result_code, get_hostname(), seed)),
-                           output)
+    set_versionstamped_key(
+        tr,
+        results[ensemble_id].key(),
+        fdb.tuple.pack((result_code, get_hostname(), seed)),
+        output,
+    )
     return True
 
 
-def insert_results(ensemble_id,
-                   seed,
-                   result_code,
-                   output,
-                   compress,
-                   sanity=False,
-                   fail_fast=0,
-                   max_runs=0,
-                   duration=0):
+def insert_results(
+    ensemble_id,
+    seed,
+    result_code,
+    output,
+    compress,
+    sanity=False,
+    fail_fast=0,
+    max_runs=0,
+    duration=0,
+):
     # Compress the results first.
     if compress:
         output = zlib.compress(output)
@@ -765,36 +802,47 @@ def insert_results(ensemble_id,
     if len(output) > BLOB_KEY_LIMIT:
         # Insert a message into the regular results stating where we are placing the actual results.
         blob_key = str(seed)
-        msg = wrap_message({
-            'Message': 'value_in_blob',
-            'BlobKey': blob_key,
-            'BlobVersion': '2'
-        })
+        msg = wrap_message(
+            {"Message": "value_in_blob", "BlobKey": blob_key, "BlobVersion": "2"}
+        )
         if compress:
             msg = zlib.compress(msg)
-        inserted = _insert_results(ensemble_id, seed, result_code, msg, sanity,
-                                   fail_fast, max_runs, duration)
+        inserted = _insert_results(
+            ensemble_id, seed, result_code, msg, sanity, fail_fast, max_runs, duration
+        )
 
         if inserted:
-            _insert_blob(db, dir_ensemble_results_large[ensemble_id][blob_key],
-                         BytesIO(output))
+            _insert_blob(
+                db, dir_ensemble_results_large[ensemble_id][blob_key], BytesIO(output)
+            )
     else:
         # Small enough to place in a single key.
-        _insert_results(ensemble_id, seed, result_code, output, sanity,
-                        fail_fast, max_runs, duration)
+        _insert_results(
+            ensemble_id,
+            seed,
+            result_code,
+            output,
+            sanity,
+            fail_fast,
+            max_runs,
+            duration,
+        )
 
 
 def _read_results(tr, results_dir, ensemble_id, begin_versionstamp):
-    for k, v in tr[results_dir[ensemble_id][begin_versionstamp]:
-                   results_dir[ensemble_id].range().stop]:
+    for k, v in tr[
+        results_dir[ensemble_id][begin_versionstamp] : results_dir[ensemble_id]
+        .range()
+        .stop
+    ]:
         yield results_dir[ensemble_id].unpack(k) + (v,)
 
 
 @fdb.transactional
 def _read_and_watch_results(tr, results_dirs, ensemble_id, begin_versionstamp):
-    result_stream = heapq.merge(*(
-        _read_results(tr, rd, ensemble_id, begin_versionstamp)
-        for rd in results_dirs))
+    result_stream = heapq.merge(
+        *(_read_results(tr, rd, ensemble_id, begin_versionstamp) for rd in results_dirs)
+    )
 
     stopAt = time.time() + 0.250
     results = []
@@ -809,10 +857,14 @@ def _read_and_watch_results(tr, results_dirs, ensemble_id, begin_versionstamp):
         return results, [], False
 
     # otherwise wait for more results to be added or the ensemble to be stopped
-    return results, [
-        tr.watch(dir_all_ensembles[ensemble_id]['count']['ended']),
-        tr.watch(dir_active[ensemble_id])
-    ], True
+    return (
+        results,
+        [
+            tr.watch(dir_all_ensembles[ensemble_id]["count"]["ended"]),
+            tr.watch(dir_active[ensemble_id]),
+        ],
+        True,
+    )
 
 
 def tail_results(ensemble_id, errors_only=False, compressed=True):
@@ -823,42 +875,50 @@ def tail_results(ensemble_id, errors_only=False, compressed=True):
     begin_versionstamp = 0
     more = True
     while more:
-        block, watches, more = _read_and_watch_results(db, result_dirs,
-                                                       ensemble_id,
-                                                       begin_versionstamp)
+        block, watches, more = _read_and_watch_results(
+            db, result_dirs, ensemble_id, begin_versionstamp
+        )
         if block:
             begin_versionstamp = block[-1][0] + 1
             for item in block:
                 text = item[-1] if not compressed else zlib.decompress(item[-1])
-                text = text.decode(encoding='utf-8', errors='backslashreplace')
+                text = text.decode(encoding="utf-8", errors="backslashreplace")
                 new_item = item[:-1] + (text,)
 
                 if is_message(text):
                     try:
                         msg = unwrap_message(text)
 
-                        if 'Message' in msg and msg[
-                                'Message'] == 'value_in_blob':
+                        if "Message" in msg and msg["Message"] == "value_in_blob":
                             # Unpack the value from the blob.
-                            key = msg['BlobKey']
+                            key = msg["BlobKey"]
                             blob_output = BytesIO()
-                            blob_version = '1' if 'BlobVersion' not in msg else msg[
-                                'BlobVersion']
+                            blob_version = (
+                                "1" if "BlobVersion" not in msg else msg["BlobVersion"]
+                            )
 
-                            if blob_version == '1':
-                                _read_blob(db, dir_ensemble_results_large[key],
-                                           blob_output)
-                            elif blob_version == '2':
+                            if blob_version == "1":
                                 _read_blob(
-                                    db, dir_ensemble_results_large[ensemble_id]
-                                    [key], blob_output)
+                                    db, dir_ensemble_results_large[key], blob_output
+                                )
+                            elif blob_version == "2":
+                                _read_blob(
+                                    db,
+                                    dir_ensemble_results_large[ensemble_id][key],
+                                    blob_output,
+                                )
                             else:
-                                raise ValueError('Unknown BlobVersion ' +
-                                                 blob_version)
-                            decompressed = zlib.decompress(blob_output.getvalue(
-                            )) if compressed else blob_output.getvalue()
-                            yield item[:-1] + (decompressed.decode(
-                                encoding='utf-8', errors='backslashreplace'),)
+                                raise ValueError("Unknown BlobVersion " + blob_version)
+                            decompressed = (
+                                zlib.decompress(blob_output.getvalue())
+                                if compressed
+                                else blob_output.getvalue()
+                            )
+                            yield item[:-1] + (
+                                decompressed.decode(
+                                    encoding="utf-8", errors="backslashreplace"
+                                ),
+                            )
                         else:
                             yield new_item
                     except Exception as e:
@@ -879,14 +939,15 @@ def _log_agent_failure(tr, timestamp, hostname, random_bytes, error_message):
 
 
 def log_agent_failure(error_message):
-    """ Log agent failure message in the database, along with timestamp and hostname.
+    """Log agent failure message in the database, along with timestamp and hostname.
     :param error_message is of type string
     """
     timestamp = int(time.time())
     hostname = get_hostname()
     random_bytes = bytes(bytearray([random.getrandbits(8) for _ in range(32)]))
-    _log_agent_failure(timestamp, hostname, random_bytes,
-                       bytes(error_message, encoding='utf-8'))
+    _log_agent_failure(
+        timestamp, hostname, random_bytes, bytes(error_message, encoding="utf-8")
+    )
 
 
 @transactional
@@ -905,10 +966,12 @@ def get_agent_failures(tr, time_start=None, time_end=None):
     failures = []
 
     for raw_failure in raw_failures:
-        raw_info = dir_failures.unpack(
-            raw_failure.key)[:-1]  # Last element is a random seed.
-        info = (datetime.fromtimestamp(
-            raw_info[0]).strftime('%Y-%b-%d (%a) %I:%M:%S %p'),) + raw_info[1:]
+        raw_info = dir_failures.unpack(raw_failure.key)[
+            :-1
+        ]  # Last element is a random seed.
+        info = (
+            datetime.fromtimestamp(raw_info[0]).strftime("%Y-%b-%d (%a) %I:%M:%S %p"),
+        ) + raw_info[1:]
         msg = raw_failure.value
 
         failures.append((info, msg))

--- a/joshua/process_handling.py
+++ b/joshua/process_handling.py
@@ -24,7 +24,13 @@
 #
 
 
-import errno, os, re, signal, subprocess, threading, time
+import errno
+import os
+import re
+import signal
+import subprocess
+import threading
+import time
 
 VAR_NAME = "OF_HOUSE_JOSHUA"
 

--- a/k8s/agent-scaler/ensemble_count.py
+++ b/k8s/agent-scaler/ensemble_count.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-#
-# ensemble_count.py
-#
+"""
+    ensemble_count.py
+"""
 # This source file is part of the FoundationDB open source project
 #
 # Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
@@ -19,39 +19,45 @@
 # limitations under the License.
 #
 
-import joshua_model
 import argparse
+import joshua_model
 
 
-def queue_size(**args):
+def queue_size():
+    """
+
+    :return:
+    """
     ensemble_list = joshua_model.list_active_ensembles()
     desired_count = 0
-    for e, props in ensemble_list:
+    for ensemble, props in ensemble_list:
         max_runs = 0
         ended = 0
-        if 'max_runs' in props:
-            max_runs = props['max_runs']
-        if 'ended' in props:
-            ended = props['ended']
+        if "max_runs" in props:
+            max_runs = props["max_runs"]
+        if "ended" in props:
+            ended = props["ended"]
         if max_runs - ended >= 0:
             desired_count += max_runs - ended
-    print(desired_count, end='')
+    print(desired_count, end="")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description='How about a nice game of chess?')
-    parser.add_argument('-C',
-                        '--cluster-file',
-                        '--cluster_file',
-                        dest="cluster_file",
-                        help="Cluster file for Joshua database")
+    parser = argparse.ArgumentParser(description="How about a nice game of chess?")
     parser.add_argument(
-        '-D',
-        '--dir-path',
-        nargs='+',
-        default=('joshua',),
-        help='top-level directory path in which joshua operates')
+        "-C",
+        "--cluster-file",
+        "--cluster_file",
+        dest="cluster_file",
+        help="Cluster file for Joshua database",
+    )
+    parser.add_argument(
+        "-D",
+        "--dir-path",
+        nargs="+",
+        default=("joshua",),
+        help="top-level directory path in which joshua operates",
+    )
 
     arguments = parser.parse_args()
     joshua_model.open(arguments.cluster_file, dir_path=arguments.dir_path)


### PR DESCRIPTION
This is the first of a few commits to cleanup this codebase. This PR applies the `black` formatter to the `*.py` files in the project. It also organizes the imports and adds "module doc strings" to comply with `pylint` rules. 