### PR TITLE
add parameter to slow down new job creation

### DIFF
--- a/k8s/agent-scaler/agent-scaler.sh
+++ b/k8s/agent-scaler/agent-scaler.sh
@@ -43,6 +43,12 @@ while true; do
             new_jobs=$((max_jobs - num_jobs))
         fi
 
+        if [ -n "${MAX_NEW_JOBS}" ]; then
+            if [ "${new_jobs}" -gt "${MAX_NEW_JOBS}" ]; then
+                new_jobs=${MAX_NEW_JOBS}
+            fi
+        fi
+
         idx=0
         while [ $idx -lt ${new_jobs} ]; do
             if [ -e /tmp/joshua-agent.yaml ]; then


### PR DESCRIPTION
This PR adds a parameter that will slow down the creation of new jobs in Kubernetes. 

The current agent scaler will attempt to create as many new jobs as are calculated. This is great for rapid scale up, but triggers more than one EC2 API rate limit when running in EKS (related to NetworkInterfaces). In an effort to avoid the API rate limits, this new parameter will compare `new_jobs` to a `max_new_jobs` and only create the lesser number of jobs for each pass in the loop. 

The default for `max_new_jobs` is the same as the default for `max_jobs` so, under a default deployment, this new logic should have no functional impact.  