### PR TITLE
Change the default namespace for the agent if JOSHUA_NAMESPACE is set

### DIFF
--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -877,6 +877,7 @@ if __name__ == "__main__":
 
     stop_file = os.environ.get("AGENT_STOPFILE", None)
 
+    name_space = os.environ.get("JOSHUA_NAMESPACE", "joshua")
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-C", "--cluster-file", default=None, help="Cluster file for Joshua database"
@@ -885,7 +886,7 @@ if __name__ == "__main__":
         "-D",
         "--dir-path",
         nargs="+",
-        default=("joshua",),
+        default=(name_space,),
         help="top-level directory path in which joshua operates",
     )
     parser.add_argument(

--- a/k8s/agent-scaler/ensemble_count.py
+++ b/k8s/agent-scaler/ensemble_count.py
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+import os
 import argparse
 import joshua_model
 
@@ -43,6 +44,7 @@ def queue_size():
 
 
 if __name__ == "__main__":
+    name_space = os.environ.get("JOSHUA_NAMESPACE", "joshua")
     parser = argparse.ArgumentParser(description="How about a nice game of chess?")
     parser.add_argument(
         "-C",
@@ -55,10 +57,10 @@ if __name__ == "__main__":
         "-D",
         "--dir-path",
         nargs="+",
-        default=("joshua",),
+        default=(name_space,),
         help="top-level directory path in which joshua operates",
     )
 
     arguments = parser.parse_args()
-    joshua_model.open(arguments.cluster_file, dir_path=arguments.dir_path)
+    joshua_model.open(arguments.cluster_file, arguments.dir_path)
     queue_size()


### PR DESCRIPTION
`JOSHUA_NAMESPACE` was not exposed to the agent.
This PR allows to change the default namespace via this environment variable on the agent.