### PR TITLE
Allow username to contain a /, and fix misc bugs

### DIFF
--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -150,6 +150,16 @@ def agent_init(work_dir):
     return True
 
 
+def sanitize_for_file_name(name):
+    """
+    >>> sanitize_for_file_name('joshua')
+    'joshua'
+    >>> sanitize_for_file_name('joshua/joshua')
+    'joshua-joshua'
+    """
+    return "".join(a if a != "/" else "-" for a in name)
+
+
 def ensemble_dir(ensemble_id=None, basepath=None):
     if not basepath:
         raise JoshuaError(
@@ -160,7 +170,10 @@ def ensemble_dir(ensemble_id=None, basepath=None):
             + ")"
         )
     return os.path.join(
-        *((basepath, "ensembles") + ((ensemble_id,) if ensemble_id else ()))
+        *(
+            (basepath, "ensembles")
+            + ((sanitize_for_file_name(ensemble_id),) if ensemble_id else ())
+        )
     )
 
 

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -417,6 +417,28 @@ class AsyncEnsemble:
         work_dir=None,
         timeout_command_timeout=60,
     ):
+        try:
+            self._run_ensemble(
+                ensemble,
+                seed,
+                save_on=save_on,
+                sanity=sanity,
+                work_dir=work_dir,
+                timeout_command_timeout=timeout_command_timeout,
+            )
+        except BaseException as e:
+            print(e)
+            self._retcode = e
+
+    def _run_ensemble(
+        self,
+        ensemble,
+        seed,
+        save_on="FAILURE",
+        sanity=False,
+        work_dir=None,
+        timeout_command_timeout=60,
+    ):
         """
         Actually run the ensemble's test script.
         :param ensemble: ensemble ID
@@ -642,6 +664,8 @@ def run_ensemble(
                 asyncEnsemble.cancel()
         else:
             assert asyncEnsemble._retcode is not None
+            if not isinstance(asyncEnsemble._retcode, int):
+                raise asyncEnsemble._retcode
             return asyncEnsemble._retcode
 
 

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -510,6 +510,8 @@ def _stop_ensemble(tr, ensemble_id, sanity=False):
         )
 
     del tr[dir[ensemble_id]]
+    del tr[dir_ensemble_incomplete[ensemble_id]]
+    del tr[dir_ensemble_incomplete[ensemble_id].range()]
     tr.add(changes, ONE)
 
 

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -658,6 +658,7 @@ def should_run_ensemble(tr: fdb.Transaction, ensemble_id: str) -> bool:
             tr.add_read_conflict_key(
                 dir_ensemble_incomplete[ensemble_id]["heartbeat"][max_seed]
             )
+            del tr[dir_ensemble_incomplete[ensemble_id][max_seed]]
             del tr[dir_ensemble_incomplete[ensemble_id][max_seed].range()]
             del tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][max_seed]]
             return True
@@ -750,6 +751,7 @@ def _insert_results(
     if tr[dir_ensemble_incomplete[ensemble_id][seed]] == None:
         # Test already completed
         return False
+    del tr[dir_ensemble_incomplete[ensemble_id][seed]]
     del tr[dir_ensemble_incomplete[ensemble_id][seed].range()]
     del tr[dir_ensemble_incomplete[ensemble_id]["heartbeat"][seed]]
 

--- a/test_joshua_agent.py
+++ b/test_joshua_agent.py
@@ -1,0 +1,7 @@
+import joshua.joshua_agent as joshua_agent
+import doctest
+
+
+def test_doctest():
+    failure_count = doctest.testmod(joshua_agent)[0]
+    assert failure_count == 0

--- a/test_joshua_model.py
+++ b/test_joshua_model.py
@@ -156,6 +156,32 @@ def test_agent(tmp_path, empty_ensemble):
     agent.join()
 
 
+def test_stop_ensemble(tmp_path, empty_ensemble):
+    """
+    :tmp_path: https://docs.pytest.org/en/stable/tmpdir.html
+    """
+    assert len(joshua_model.list_active_ensembles()) == 0
+    ensemble_id = joshua_model.create_ensemble(
+        "joshua", {"max_runs": 1e12}, open(empty_ensemble, "rb")
+    )
+    agent = threading.Thread(
+        target=joshua_agent.agent,
+        args=(),
+        kwargs={
+            "work_dir": tmp_path,
+            "agent_idle_timeout": 1,
+        },
+    )
+    agent.setDaemon(True)
+    agent.start()
+    while len(joshua_model.show_in_progress(ensemble_id)) == 0:
+        time.sleep(0.001)
+    joshua.stop_ensemble(ensemble_id, username="joshua")
+    assert joshua_model.show_in_progress(ensemble_id) == []
+    joshua.tail_ensemble(ensemble_id, username="joshua")
+    agent.join()
+
+
 def test_dead_agent(tmp_path, empty_ensemble):
     """
     :tmp_path: https://docs.pytest.org/en/stable/tmpdir.html

--- a/test_joshua_model.py
+++ b/test_joshua_model.py
@@ -140,7 +140,7 @@ def test_agent(tmp_path, empty_ensemble):
     """
     assert len(joshua_model.list_active_ensembles()) == 0
     ensemble_id = joshua_model.create_ensemble(
-        "joshua", {"max_runs": 1}, open(empty_ensemble, "rb")
+        "joshua/joshua", {"max_runs": 1}, open(empty_ensemble, "rb")
     )
     agent = threading.Thread(
         target=joshua_agent.agent,
@@ -152,7 +152,7 @@ def test_agent(tmp_path, empty_ensemble):
     )
     agent.setDaemon(True)
     agent.start()
-    joshua.tail_ensemble(ensemble_id, username="joshua")
+    joshua.tail_ensemble(ensemble_id, username="joshua/joshua")
     agent.join()
 
 


### PR DESCRIPTION
Previously stopping an ensemble could leak some keys in `dir_ensemble_incomplete`, and agents could heartbeat for a test after completing that test.