### PR TITLE
Add a newline to wrapped messages

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -145,7 +145,7 @@ def transactional(func):
 def wrap_error(description):
     root = ET.Element("Test")
     ET.SubElement(root, "JoshuaError", {"Severity": "40", "ErrorMessage": description})
-    return ET.tostring(root)
+    return ET.tostring(root) + "\n"
 
 
 def wrap_message(info={}):
@@ -153,7 +153,7 @@ def wrap_message(info={}):
     attribs = {"Severity": "10"}
     attribs.update(info)
     ET.SubElement(root, "JoshuaMessage", attribs)
-    return ET.tostring(root)
+    return ET.tostring(root) + "\n"
 
 
 def get_hostname():


### PR DESCRIPTION
There are currently certain error situations where the output trace XML from joshua does not include a newline before the closing `</Trace>` element. Certain tools used to parse this XML don't currently react well when this happens.

To keep the output more consistent, this change adds a newline to each string created by `wrap_message` or `wrap_error`.