### PR TITLE
Read started at serializable isolation in should_run_ensemble

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -630,7 +630,7 @@ def should_run_ensemble(tr: fdb.Transaction, ensemble_id: str) -> bool:
     policy tries not to overshoot max_runs by too much, but also accounts
     for the possibility that agents might die.
     """
-    props = _get_ensemble_properties(tr, ensemble_id, snapshot=True)
+    props = _get_ensemble_properties(tr, ensemble_id)
     started = props.get("started", 0)
     max_runs = props.get("max_runs", 0)
     # max_runs == 0 means run forever


### PR DESCRIPTION
This lowers the rate at which tests can start for an ensemble, but it makes it less likely that a long-running test is ignored because we started more than max_runs tests (due to reading at snapshot isolation)

After this change, the only way to overrun max_runs should be if an agent fails. We could modify this transaction to decrement started when work-stealing happens if we want to make it an invariant that started <= max_runs