### PR TITLE
Support tarball in S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN yum repolist && \
     pip3 install \
         python-dateutil \
         subprocess32 \
-        psutil && \
+        psutil \
+        boto3 && \
     gem install ffi --platform=ruby && \
     groupadd -r joshua -g 4060 && \
     useradd \

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -126,15 +126,21 @@ def start_ensemble(
     if command:
         properties["test_command"] = command
     print("Starting ensemble")
-    with open(tarball, "rb") as tarfile:
-        tarfile.seek(0, os.SEEK_END)
-        size = tarfile.tell()
-        tarfile.seek(0, os.SEEK_SET)
-        properties["data_size"] = size
-
+    # if s3 URL is passed, passthrough the URL
+    if tarball.startswith("s3://"):
         ensemble_id = joshua_model.create_ensemble(
-            username, properties, tarfile, sanity
+            username, properties, tarball, sanity, True
         )
+    else:
+        with open(tarball, "rb") as tarfile:
+            tarfile.seek(0, os.SEEK_END)
+            size = tarfile.tell()
+            tarfile.seek(0, os.SEEK_SET)
+            properties["data_size"] = size
+
+            ensemble_id = joshua_model.create_ensemble(
+                username, properties, tarfile, sanity, False
+            )
     print(format_ensemble(ensemble_id, properties))
     return str(ensemble_id)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,3 +15,4 @@ subprocess32==3.5.4
 toml==0.10.2
 typing-extensions==3.10.0.0
 zipp==3.4.1
+boto3==1.23.10

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,3 +16,4 @@ toml==0.10.2
 typing-extensions==3.10.0.0
 zipp==3.4.1
 boto3==1.23.10
+moto[s3]==3.1.10


### PR DESCRIPTION
This PR allows users to specify an S3 URL for `--tarball` argument.
When an S3 URL is specified, the package won't be copied into FDB. Instead, the agent directly downloads it from S3.

This PR introduces 2 behavior changes:
- AWS credentials must be properly setup on both the client and the agent
- `boto3` package is required