### PR TITLE
set env variables for test harness to write metadata

### DIFF
--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -512,6 +512,9 @@ class AsyncEnsemble:
                 continue
             env["JOSHUA_" + k.upper()] = str(v)
         env["JOSHUA_SEED"] = str(seed).rstrip("L")
+        env['JOSHUA_APP_DIR'] = ",".join(list(joshua_model.get_application_dir(ensemble)))
+        if joshua_model.cluster_file is not None:
+            env['JOSHUA_CLUSTER_FILE'] = joshua_model.cluster_file
         # process_handling.ensure_path(env)
 
         #    print('{} Running ensemble in dir: {}'.format(threading.current_thread().name, work_dir),file=getFileHandle())


### PR DESCRIPTION
`TestHarness` writes some metadata (mostly code coverage, in a future version also statistics) implicitly through its output into the fdb cluster. However, we're mostly interested in the aggregate of these. Therefore it would be more efficient if `TestHarness` would write the metadata to FDB in aggregated form.

This change allows future versions of `TestHarness` to do just that by passing the cluster file and the application directory to the test through environment variables