### PR TITLE
Add boto3 to the scaler image

### DIFF
--- a/k8s/agent-scaler/Dockerfile
+++ b/k8s/agent-scaler/Dockerfile
@@ -40,7 +40,9 @@ ENV LD_LIBRARY_PATH="/lib64:$LD_LIBRARY_PATH"
 
 # FDB python binding
 RUN source /opt/rh/rh-python38/enable && \
-    pip3 install foundationdb==6.3.18
+    pip3 install \
+        foundationdb==6.3.18 \
+	boto3
 
 ENV BATCH_SIZE=1
 ENV MAX_JOBS=10


### PR DESCRIPTION
joshua_model.py now depends on boto3.
We need to add boto3 to the scaler image too (in addition to the agent image).