### PR TITLE
Install criu in the joshua agent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN yum repolist && \
         yum-utils && \
     yum -y install \
         bzip2 \
+        criu \
         devtoolset-8 \
         devtoolset-8-libasan-devel \
         devtoolset-8-liblsan-devel \


### PR DESCRIPTION
[Criu](https://criu.org/Main_Page) is a tool to checkpoint and restore linux processes. We have some ideas around using checkpointing to improving debuggability for joshua ensembles, especially in cases where the tests take a long time to run or the tests time out.