### PR TITLE
Use Pod labels for better manageability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN yum repolist && \
         python-dateutil \
         subprocess32 \
         psutil \
+        kubernetes \
         boto3 && \
     gem install ffi --platform=ruby && \
     groupadd -r joshua -g 4060 && \

--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -410,6 +410,17 @@ def download_ensemble(ensemble, out=None, force=False, sanity=False, **args):
     print("Download completed")
 
 
+def agent_tag(set=None, clear=False, **args):
+    if set is not None:
+        joshua_model.set_agent_tag(set)
+    elif clear == True:
+        joshua_model.clear_agent_tag()
+    else:
+        tag = joshua_model.get_agent_tag()
+        if tag is not None:
+            print(tag)
+
+
 if __name__ == "__main__":
     name_space = os.environ.get("JOSHUA_NAMESPACE", "joshua")
     parser = argparse.ArgumentParser(description="How about a nice game of chess?")
@@ -694,6 +705,21 @@ if __name__ == "__main__":
         help="ensemble in question is a sanity ensemble",
     )
     parser_download.set_defaults(cmd=download_ensemble)
+
+    # agent_tag is a hidden command only used in k8s environments
+    parser_agent_tag = subparsers.add_parser("agent_tag", usage=argparse.SUPPRESS)
+    parser_agent_tag.add_argument(
+        "--set",
+        default=None,
+        help="set a new agent tag",
+    )
+    parser_agent_tag.add_argument(
+        "--clear",
+        default=False,
+        action="store_true",
+        help="clear agent tag",
+    )
+    parser_agent_tag.set_defaults(cmd=agent_tag)
 
     arguments = parser.parse_args()
 

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -87,12 +87,13 @@ dir_ensemble_results_application = None
 dir_active_changes = None
 dir_sanity_changes = None
 dir_failures = None
+dir_agent_tag = None
 
 
 def open(c_file=None, dir_path=("joshua",)):
     global cluster_file, db, dir_top, dir_ensembles, dir_active, dir_sanity, dir_all_ensembles, dir_ensemble_data
     global dir_ensemble_results, dir_ensemble_results_pass, dir_ensemble_results_fail, dir_ensemble_incomplete
-    global dir_ensemble_results_large, dir_ensemble_results_application, dir_active_changes, dir_sanity_changes, dir_failures
+    global dir_ensemble_results_large, dir_ensemble_results_application, dir_active_changes, dir_sanity_changes, dir_failures, dir_agent_tag
 
     cluster_file = c_file
     db = fdb.open(cluster_file)
@@ -109,6 +110,7 @@ def open(c_file=None, dir_path=("joshua",)):
     dir_ensemble_results_large = dir_ensemble_results.create_or_open(db, "large")
     dir_ensemble_results_application = dir_ensemble_results.create_or_open(db, "application")
     dir_failures = dir_top.create_or_open(db, "failures")
+    dir_agent_tag = dir_top.create_or_open(db, "agent_tag")
 
     dir_active_changes = dir_active
     dir_sanity_changes = dir_sanity
@@ -1023,3 +1025,23 @@ def get_agent_failures(tr, time_start=None, time_end=None):
         failures.append((info, msg))
 
     return failures
+
+
+@transactional
+def get_agent_tag(tr: fdb.Transaction) -> Optional[str]:
+    ret = None
+    try:
+        val = tr[dir_agent_tag].value
+        if val is not None:
+            ret = val.decode('utf-8')
+    except NameError:
+        pass
+    return ret
+
+@transactional
+def set_agent_tag(tr: fdb.Transaction, tag_str: str) -> None:
+    tr[dir_agent_tag] = tag_str.encode('utf-8')
+
+@transactional
+def clear_agent_tag(tr: fdb.Transaction) -> None:
+    del tr[dir_agent_tag]

--- a/k8s/agent-scaler/Dockerfile
+++ b/k8s/agent-scaler/Dockerfile
@@ -23,11 +23,13 @@ RUN yum repolist && \
 # agent-scaler tools
 COPY agent-scaler.sh /tools/
 COPY ensemble_count.py /tools/
+COPY get_agent_tag.py /tools/
 COPY joshua_model.py /tools/
 
 RUN chmod +x \
     /tools/agent-scaler.sh \
     /tools/ensemble_count.py \
+    /tools/get_agent_tag.py \
     /tools/joshua_model.py
 
 # libfdb_c.so

--- a/k8s/agent-scaler/configmap.yaml
+++ b/k8s/agent-scaler/configmap.yaml
@@ -15,12 +15,17 @@ data:
     metadata:
       name: joshua-agent-${JOBNAME_SUFFIX}
       namespace: joshua
+      labels:
+        app: joshua-agent
     spec:
       template:
+        metadata:
+          labels:
+            app: joshua-agent
         spec:
           containers:
           - name: joshua-agent-container
-            image: foundationdb/joshua-agent:latest
+            image: ${AGENT_TAG}
             imagePullPolicy: IfNotPresent
             env:
             - name: AGENT_TIMEOUT
@@ -36,6 +41,7 @@ data:
                 items:
                   - key: fdb.cluster
                     path: fdb.cluster
+          serviceAccountName: joshua-agent-sa
           restartPolicy: Never
 kind: ConfigMap
 metadata:

--- a/k8s/agent-scaler/joshua.yaml
+++ b/k8s/agent-scaler/joshua.yaml
@@ -27,6 +27,7 @@ rules:
   - list
   - create
   - delete
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -42,6 +43,40 @@ subjects:
   name: joshua-sa
   namespace: joshua
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: joshua-agent-sa
+  namespace: joshua
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: joshua-agent-role
+  namespace: joshua
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: joshua-agent-role-binding
+  namespace: joshua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: joshua-agent-role
+subjects:
+- kind: ServiceAccount
+  name: joshua-agent-sa
+  namespace: joshua
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -53,4 +88,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: joshua-sa
+  namespace: joshua
+- kind: ServiceAccount
+  name: joshua-agent-sa
   namespace: joshua

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,4 +16,5 @@ toml==0.10.2
 typing-extensions==4.3.0
 zipp==3.8.1
 boto3==1.24.87
+kubernetes==25.3.0
 moto[s3]==4.0.6

--- a/test_joshua_model.py
+++ b/test_joshua_model.py
@@ -553,3 +553,17 @@ def test_two_agents_large_ensemble(monkeypatch, tmp_path, empty_ensemble):
 
     for agent in agents:
         agent.join()
+
+
+def test_agent_tag(tmp_path, empty_ensemble):
+    tag = "test_tag"
+
+    # clear tag
+    joshua_model.clear_agent_tag()
+    assert joshua_model.get_agent_tag() == None
+
+    # set tag
+    joshua_model.set_agent_tag(tag)
+    assert joshua_model.get_agent_tag() == tag
+
+    joshua_model.clear_agent_tag()


### PR DESCRIPTION
This PR contains the following new capabilities:
- An agent scaler creates Joshua agents with a known tag baked in as AGENT_TAG. This prevents mismatching versions between the scaler and the agents
- At the boot time, an agent scaler requests all running agents to exit after the current ensemble. This guarantees to recreate agents in case both agents and the scaler are updated.
- Add a hidden command `agent_tag` in Joshua CLI. When `ENABLE_DYNAMIC_AGENT_TAG` argument is passed to the scaler, the scaler uses the agent tag stored in FDB.
- Agent pods will have a proper `app` label as `joshua-agent`
- Each agent writes its current ensemble in the Pod label `ensemble`
  ```
  $ kubectl --namespace joshua get pods -L app,ensemble
  NAME                                       READY   STATUS              RESTARTS   AGE   APP            ENSEMBLE
  agent-scaler-deployment-86c984887f-vdzpv   1/1     Running             0          45s   agent-scaler
  joshua-agent-221118030447-0-57dtx          1/1     Running             0          3s    joshua-agent   20221118-030444-kmakino-f067840ad81ea406
  joshua-agent-221118030447-1-mjtdf          1/1     Running             0          2s    joshua-agent   20221118-030444-kmakino-f067840ad81ea406
  joshua-agent-221118030447-2-647qb          1/1     Running             0          2s    joshua-agent   20221118-030444-kmakino-f067840ad81ea406
  joshua-agent-221118030447-3-clnhq          1/1     Running             0          2s    joshua-agent   20221118-030444-kmakino-f067840ad81ea406
  joshua-agent-221118030447-4-h6jgn          0/1     ContainerCreating   0          2s    joshua-agent   20221118-030444-kmakino-f067840ad81ea406
  ```
- 