### PR TITLE
Fix trackback printing error

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -967,9 +967,9 @@ def tail_results(ensemble_id, errors_only=False, compressed=True):
                             )
                         else:
                             yield new_item
-                    except Exception as e:
+                    except Exception:
                         # Could not parse the message. Just yield the item.
-                        traceback.print_exc(e)
+                        traceback.print_exc()
                         yield new_item
                 else:
                     yield new_item


### PR DESCRIPTION
Fix #84

"print_exc" expect the first parameter as limit, which can't be an exception.