### PR TITLE
Fix very long user IDs

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -430,9 +430,10 @@ def create_ensemble(userid, properties, tarball, sanity=False, use_s3=False):
     else:
         hash = get_hash(tarball)
     timestamp = format_datetime(datetime.datetime.now(datetime.timezone.utc))
-    ensemble_id_candidate = timestamp + "-" + userid + "-" + hash[:16]
-    # trim this because kubernetes labels are limited to 63 characters
-    ensemble_id = ensemble_id_candidate[:60]
+    # Trim this because kubernetes labels are limited to 63 characters
+    # See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # So we use 15 + 1 + 27 + 1 + 16 = 60 here.
+    ensemble_id = timestamp + "-" + userid[:27] + "-" + hash[:16]
     if "submitted" not in properties:
         properties["submitted"] = timestamp
     if not use_s3:


### PR DESCRIPTION
User ID is used as part of ensemble name, which is limited to be 63 bytes long. When user ID becomes long, the original logic truncate the ensemble such that a non-alphanumeric character can be the last one, causing failures in k8s like:

{"reason":"FieldValueInvalid","message":"Invalid value: \"20250514-000408-XXXXX-XXXXXXX-XXXXX-XXXXXXXXXXX-XXXXXX-XXXX-\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')","field":"metadata.labels"}]},"code":422}