### PR TITLE
Allow joshua-rhel9-agent to schedule jobs even when joshua-agent jobs…

### DIFF
--- a/k8s/agent-scaler/agent-scaler.sh
+++ b/k8s/agent-scaler/agent-scaler.sh
@@ -24,70 +24,99 @@ while true; do
 
     if [ $use_k8s_ttl_controller == false ] ; then
       # cleanup finished jobs (status 1/1)
-      for job in $(kubectl get jobs -n "${namespace}" --no-headers | grep -E -e 'joshua-agent-[0-9-]*\s*1/1' | awk '{print $1}'); do
-          echo "=== Job $job Completed ==="
+      # Filter by AGENT_NAME and check 3rd column for "1/1" (completions)
+      for job in $(kubectl get jobs -n "${namespace}" --no-headers | { grep -E -e "^${AGENT_NAME}-[0-9]+(-[0-9]+)?\\s" || true; } | awk '$3 == "1/1" {print $1}'); do
+          echo "=== Job $job Completed (1/1) - deleting from get jobs === (AGENT_NAME: ${AGENT_NAME})"
           kubectl delete job "$job" -n "${namespace}"
       done
 
-      # cleanup failed jobs
+      # cleanup failed/completed jobs by looking at pods for the current AGENT_NAME
       # pod name is always prefixed with the job name
-      # e.g. "joshua-agent-XXXXXXXXXXXX-XX-yyyyy"
-      for job in $(kubectl get pods -n "${namespace}" --no-headers | grep -E -e "Completed" -e "Error" | cut -f 1-4 -d '-') ; do
-          echo "=== Deleting Job $job ==="
-          kubectl delete job "$job" -n "${namespace}"
+      # e.g. "joshua-agent-XXXXXXXXXXXXXX-XX-yyyyy" or "joshua-rhel9-agent-XXXXXXXXXXXXXX-XX-yyyyy"
+      # Filter pods by AGENT_NAME first, then by status, then extract job prefix
+      # The number of fields to cut for the job prefix depends on the number of hyphens in AGENT_NAME itself, plus one for the timestamp part.
+      num_hyphen_fields_in_agent_name=$(echo "${AGENT_NAME}" | awk -F'-' '{print NF}')
+      job_prefix_fields=$((num_hyphen_fields_in_agent_name + 1))
+      for job_prefix in $(kubectl get pods -n "${namespace}" --no-headers | { grep -E "^${AGENT_NAME}-[0-9]+(-[0-9]+)?-" || true; } | { grep -E -e "Completed" -e "Error" || true; } | cut -f 1-${job_prefix_fields} -d '-'); do
+          if [ -n "$job_prefix" ]; then
+            echo "=== Deleting Job based on pod status: $job_prefix === (AGENT_NAME: ${AGENT_NAME})"
+            kubectl delete job "$job_prefix" -n "${namespace}" --ignore-not-found=true
+          fi
       done
     fi
 
     # get the current ensembles
     num_ensembles=$(python3 /tools/ensemble_count.py)
-    echo "${num_ensembles} ensembles in the queue"
+    echo "${num_ensembles} ensembles in the queue (global)"
 
-    # get the current jobs
-    num_jobs=$(kubectl get jobs -n "${namespace}" --no-headers | wc -l)
-    echo "${num_jobs} jobs are running"
+    # get the current number of ALL active joshua jobs (rhel9, non-rhel9, etc.)
+    # This counts jobs that are not yet successfully completed or failed.
+    num_all_active_joshua_jobs=$(kubectl get jobs -n "${namespace}" -o jsonpath='{range .items[?(!(@.status.conditions[?(@.type=="Complete"&&@.status=="True")]) && !(@.status.conditions[?(@.type=="Failed"&&@.status=="True")]))]}{.metadata.name}{"\\n"}{end}' 2>/dev/null | grep -Ec "^joshua-(rhel9-)?agent-[0-9]+(-[0-9]+)?$")
+    echo "${num_all_active_joshua_jobs} total active joshua jobs (any type) are running. Global max_jobs: ${max_jobs}."
 
-    # provision more jobs
-    if [ "${num_ensembles}" -gt "${num_jobs}" ]; then
+    new_jobs=0 # Initialize jobs to start this cycle for this scaler
+
+    # Provision more jobs if global ensembles exist and the global max_jobs limit is not reached.
+    if [ "${num_ensembles}" -gt 0 ] && [ "${num_all_active_joshua_jobs}" -lt "${max_jobs}" ]; then
         current_timestamp="$(date +%y%m%d%H%M%S)"
-        new_jobs=$((num_ensembles - num_jobs))
 
-        if [ ${new_jobs} -gt $((max_jobs - num_jobs)) ]; then
-            new_jobs=$((max_jobs - num_jobs))
+        # How many slots are available globally before hitting max_jobs
+        slots_available_globally=$((max_jobs - num_all_active_joshua_jobs))
+
+        # Determine how many jobs this scaler instance will attempt to start in this cycle
+        num_to_attempt_this_cycle=${batch_size} # Start with batch_size as the base
+
+        # If MAX_NEW_JOBS is set and is smaller than current num_to_attempt_this_cycle, respect it
+        if [ -n "${MAX_NEW_JOBS}" ]; then
+            if [ "${MAX_NEW_JOBS}" -lt "${num_to_attempt_this_cycle}" ]; then
+                num_to_attempt_this_cycle=${MAX_NEW_JOBS}
+            fi
         fi
 
-        if [ -n "${MAX_NEW_JOBS}" ]; then
-            if [ "${new_jobs}" -gt "${MAX_NEW_JOBS}" ]; then
-                new_jobs=${MAX_NEW_JOBS}
-            fi
+        # The actual number of new jobs for this scaler is the minimum of what it wants to attempt 
+        # and what's available globally.
+        if [ "${num_to_attempt_this_cycle}" -gt "${slots_available_globally}" ]; then
+            actual_new_jobs_for_this_scaler=${slots_available_globally}
+        else
+            actual_new_jobs_for_this_scaler=${num_to_attempt_this_cycle}
+        fi
+        
+        # Ensure we are trying to start a positive number of jobs
+        if [ "${actual_new_jobs_for_this_scaler}" -gt 0 ]; then
+            new_jobs=${actual_new_jobs_for_this_scaler}
         fi
 
         idx=0
-        echo "Starting ${new_jobs} jobs"
-        while [ $idx -lt ${new_jobs} ]; do
-            if [ -e /tmp/joshua-agent.yaml ]; then
-                rm -f /tmp/joshua-agent.yaml
-            fi
-            i=0
-            while [ $i -lt "${batch_size}" ]; do
-                export JOBNAME_SUFFIX="${current_timestamp}-${idx}"
-                echo "=== Adding $JOBNAME_SUFFIX ==="
-                envsubst </template/joshua-agent.yaml.template >>/tmp/joshua-agent.yaml
-                # add a separator
-                echo "---" >>/tmp/joshua-agent.yaml
-                ((idx++))
-                ((i++))
-                if [ "${idx}" -ge ${new_jobs} ]; then
-                    break
+        if [ "${new_jobs}" -gt 0 ]; then
+            echo "Starting ${new_jobs} jobs"
+            while [ $idx -lt ${new_jobs} ]; do
+                if [ -e /tmp/joshua-agent.yaml ]; then
+                    rm -f /tmp/joshua-agent.yaml
                 fi
+                i=0
+                while [ $i -lt "${batch_size}" ]; do
+                    export JOBNAME_SUFFIX="${current_timestamp}-${idx}"
+                    echo "=== Adding $JOBNAME_SUFFIX ==="
+                    envsubst </template/joshua-agent.yaml.template >>/tmp/joshua-agent.yaml
+                    # add a separator
+                    echo "---" >>/tmp/joshua-agent.yaml
+                    ((idx++))
+                    ((i++))
+                    if [ "${idx}" -ge ${new_jobs} ]; then
+                        break
+                    fi
+                done
+                # /tmp/joshua-agent.yaml contains up to $batch_size entries
+                echo "Starting a batch of ${i} jobs"
+                kubectl apply -f /tmp/joshua-agent.yaml -n "${namespace}"
             done
-            # /tmp/joshua-agent.yaml contains up to $batch_size entries
-            echo "Starting a batch of ${i} jobs"
-            kubectl apply -f /tmp/joshua-agent.yaml -n "${namespace}"
-        done
+        fi
     fi
-    echo "${new_jobs} jobs started"
+    # Standardized log message based on new_jobs calculated for this iteration for this agent type
+    echo "${new_jobs} jobs of type ${AGENT_NAME} were targeted for starting in this iteration."
 
     # check every check_delay seconds
     sleep "${check_delay}"
 done
 exit 0
+


### PR DESCRIPTION
… are running (up to MAX_JOBS total). rhel9 jobs were being shut out if joshua-agent jobs were running until queued ensemble count was < jobs running count: now jobs will be scheduled as long as we stay under MAX_JOBS count.

Fix cleanup so we do rhel9 job cleanup only in this script -- make general use of the AGENT_NAME varible.

Patch is against the rockylinux9 branch.

To debug, I logged into the joshua agent-scaler for rhel9 pod and then ran agent-scheduler.sh with bash -x command. I saw that if a queued ensemble, it would not run jobs... not until the count of jobs fell below the count of queued ensembles (rare event). I then ran the patched agent-scheduler.sh and it runs jobs more freely with a mix of rhel9 and centos jobs.  
