### PR TITLE
Add new line after joshua-agent.yaml.template

### DIFF
--- a/k8s/agent-scaler/agent-scaler.sh
+++ b/k8s/agent-scaler/agent-scaler.sh
@@ -228,7 +228,7 @@ while true; do
                     echo "=== Adding $JOBNAME_SUFFIX ==="
                     envsubst </template/joshua-agent.yaml.template >>/tmp/joshua-agent.yaml
                     # add a separator
-                    echo "---" >>/tmp/joshua-agent.yaml
+                    printf '\n---\n' >>/tmp/joshua-agent.yaml
                     ((idx++))
                     ((i++))
                     if [ "${idx}" -ge ${new_jobs} ]; then


### PR DESCRIPTION
Prior to this change, I was seeing Joshua jobs fail with:

```
The Job "joshua-agent-260204060022-62" is invalid:
* spec.template.spec.restartPolicy: Unsupported value: "Never---": supported values: "Always", "OnFailure", "Never
```

due to the `---` string being added directly after the restart policy from `configmap.yaml`.