### PR TITLE
Add `JOSHUA_AGENT_HEARTBEAT_INTERVAL` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ architecture is essentially as follows:
  * The Joshua agent should be run in the various machines where one would like
    jobs to be executed. It will look for jobs to run (called ensembles) by looking 
    for updates from a coordinating FoundationDB cluster.
+   Set `JOSHUA_AGENT_HEARTBEAT_INTERVAL` to override the interval, in seconds,
+   between heartbeats for a running job. The default is `1.0`.
 
  * Jobs should be submitted through a Joshua client that pushes a package to
    run as well as adding an ensemble name into the same coordinating database.

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -59,6 +59,21 @@ jobs_fail = 0
 stop_agent = False
 
 
+def get_heartbeat_interval():
+    interval = os.environ.get("JOSHUA_AGENT_HEARTBEAT_INTERVAL", "1.0")
+    try:
+        interval = float(interval)
+    except ValueError:
+        raise JoshuaError(
+            "JOSHUA_AGENT_HEARTBEAT_INTERVAL must be a positive number of seconds"
+        )
+    if interval <= 0.0:
+        raise JoshuaError(
+            "JOSHUA_AGENT_HEARTBEAT_INTERVAL must be a positive number of seconds"
+        )
+    return interval
+
+
 # This is thrown by Joshua to indicate that there was an error.
 class JoshuaError(Exception):
     def __init__(self, msg):
@@ -700,8 +715,9 @@ class AsyncEnsemble:
         asyncDoneArgs = (done_args, where, env)
         doneChild = threading.Thread(target=asyncDone.run, args=asyncDoneArgs)
         doneChild.start()
+        heartbeat_interval = get_heartbeat_interval()
         while doneChild.is_alive():
-            doneChild.join(1.0)
+            doneChild.join(heartbeat_interval)
             if not joshua_model.heartbeat_and_check_running(ensemble, seed, sanity):
                 asyncDone.cancel()
 
@@ -776,8 +792,9 @@ def run_ensemble(
     )
     asyncEnsembleThread.setDaemon(True)
     asyncEnsembleThread.start()
+    heartbeat_interval = get_heartbeat_interval()
     while True:
-        asyncEnsembleThread.join(timeout=1)  # heartbeating frequency
+        asyncEnsembleThread.join(timeout=heartbeat_interval)
         if asyncEnsembleThread.is_alive():
             if not joshua_model.heartbeat_and_check_running(ensemble, seed, sanity):
                 asyncEnsemble.cancel()


### PR DESCRIPTION
When running many agents with a relatively small FDB cluster, heartbeating every second can be expensive. This PR supports using an environment variable to configure the heartbeating interval