### PR TITLE
Symlink python3 to the new 3.13 python else the python3 reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN dnf update -y && \
         libffi-devel \
         libatomic \
         valgrind && \
+    ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
+    ln -sf /usr/bin/pip3.13 /usr/bin/pip3 && \
     # This should be moved into a dedicated step with a requirements file + version pinning.
     python3.13 -m pip install \
         python-dateutil \


### PR DESCRIPTION
in TestHarnes picks up system python which is missing fdb lib, etc.

Editing TestHarness over in foundationdb to do the below made it work again (previous it was just exiting immediately with -1)
```

diff --git a/contrib/Joshua/scripts/correctnessTest.sh b/contrib/Joshua/scripts/correctnessTest.sh
index ef1abd78e0..8402e25b9e 100755
--- a/contrib/Joshua/scripts/correctnessTest.sh
+++ b/contrib/Joshua/scripts/correctnessTest.sh
@@ -264,7 +264,7 @@ PYTHON_APP_STDERR_FILE="${APP_RUN_TEMP_DIR}/python_app_stderr.log"
 echo "Executing TestHarness2 with seed ${JOSHUA_SEED}..." >&2

 # Run TestHarness - output goes to stdout via tee AND gets saved to file
-python3 -m test_harness.app "${PYTHON_CMD_ARGS[@]}" 2> "${PYTHON_APP_STDERR_FILE}" | tee "${PYTHON_APP_STDOUT_FILE}"
+python3.13 -m test_harness.app "${PYTHON_CMD_ARGS[@]}" 2> "${PYTHON_APP_STDERR_FILE}" | tee "${PYTHON_APP_STDOUT_FILE}"
 PYTHON_EXIT_CODE=$?

 echo "TestHarness2 execution finished. Exit code: ${PYTHON_EXIT_CODE}" >&2
```