### PR TITLE
Symlink python3 to python3.13 in agent-scaler Dockerfile

### DIFF
--- a/k8s/agent-scaler/Dockerfile
+++ b/k8s/agent-scaler/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf -y update && \
         jq-1.6 \
         python3.13 \
         python3.13-pip && \
+    ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
     dnf -y clean all --enablerepo='*' && \
     case $(uname -m) in \
             x86_64) curl -Ls https://dl.k8s.io/release/v1.27.5/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl;; \


### PR DESCRIPTION
Same fix as 86508ce but for the agent-scaler container. Without this, agent-scaler.sh invokes `python3` which resolves to system python 3.9 that has no packages installed (fdb, boto3 are in python3.13).