### PR TITLE
slim joshua-agent Dockerfile / container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN python3 -m pip install \
         python-dateutil \
         subprocess32 \
         psutil \
-        kubernetes \
+        kubernetes==30.1.0 \
         urllib3==1.26.20 \
         boto3==1.43.14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,11 @@ RUN if [ "$(uname -p)" == "x86_64" ]; then \
 ENV FDB_CLUSTER_FILE=/etc/foundationdb/fdb.cluster
 ENV AGENT_TIMEOUT=300
 
+# joshua-agent often needs huge retry limits
+# because of thundering-herd of thousands of agents doing joshua_model.try_running_test()
+ENV TRANSACTION_TIMEOUT_MS=256000
+ENV TRANSACTION_RETRY_LIMIT=1000
+
 USER joshua
 CMD python3 -m joshua.joshua_agent \
         -C ${FDB_CLUSTER_FILE} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:9.6
+FROM rockylinux/rockylinux:9.7
 # This is joshua-agent
 
 WORKDIR /tmp
@@ -11,34 +11,29 @@ RUN dnf update -y && \
         dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
     dnf install -y \
-        bzip2 \
-        xz \
-        criu \
-        gettext \
-        golang \
-        java-11-openjdk-devel \
-        mono-core \
+        lsof \
         net-tools \
+        procps-ng \
         python3.13 \
         python3.13-devel \
         python3.13-pip \
-        ruby \
-        ruby-devel \
         libffi-devel \
-        libatomic \
-        valgrind && \
-    ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
-    ln -sf /usr/bin/pip3.13 /usr/bin/pip3 && \
-    # This should be moved into a dedicated step with a requirements file + version pinning.
-    python3.13 -m pip install \
+        gcc && \
+    dnf -y clean all --enablerepo='*'
+
+RUN ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
+    ln -sf /usr/bin/pip3.13 /usr/bin/pip3
+
+# This should be moved into a dedicated step with a requirements file + version pinning.
+RUN python3 -m pip install \
         python-dateutil \
         subprocess32 \
         psutil \
         kubernetes \
-        urllib3==1.26.14 \
-        boto3==1.43.4 && \
-    gem install ffi --platform=ruby && \
-    groupadd -r joshua -g 4060 && \
+        urllib3==1.26.20 \
+        boto3==1.43.14
+
+RUN groupadd -r joshua -g 4060 && \
     useradd \
         -rm \
         -d /home/joshua \
@@ -47,74 +42,27 @@ RUN dnf update -y && \
         -g joshua \
         joshua && \
     mkdir -p /var/joshua && \
-    chown -R joshua:joshua /var/joshua && \
-    rm -rf /tmp/*
+    chown -R joshua:joshua /var/joshua
 
 # Install Joshua client
 COPY childsubreaper/ /opt/joshua/install/childsubreaper
 COPY joshua/ /opt/joshua/install/joshua
 COPY setup.py /opt/joshua/install/
-RUN ARTIFACT=client python3.13 -m pip install /opt/joshua/install && \
+RUN ARTIFACT=client python3 -m pip install /opt/joshua/install && \
     rm -rf /opt/joshua/install
 
-# install old fdbserver binaries and libfdb_c.so
-# Skip these old versions: 6.2.30 6.2.29 6.2.28 6.2.27 6.2.26 6.2.25 6.2.24 6.2.23 6.2.22 6.2.21 6.2.20 6.2.19 6.2.18 6.2.17 6.2.16 6.2.15 6.2.10 6.1.13 6.1.12 6.1.11 6.1.10 6.0.18 6.0.17 6.0.16 6.0.15 6.0.14 5.2.8 5.2.7 5.1.7 5.1.6
-# because 7.3 no longer supports upgrade from these versions.
-ARG OLD_FDB_BINARY_DIR=/app/deploy/global_data/oldBinaries/
 ARG FDB_VERSION="7.1.57"
+# This image only works for x86_64 ...
 RUN if [ "$(uname -p)" == "x86_64" ]; then \
-        mkdir -p ${OLD_FDB_BINARY_DIR} \
-                 /usr/lib/foundationdb/plugins && \
-        for old_fdb_server_version in 7.4.3 7.3.69 7.3.63 7.3.57 7.3.43 7.1.61 7.1.57 7.1.43 7.1.35 7.1.33 7.1.27 7.1.25 7.1.23 7.1.19 6.3.18 6.3.17 6.3.16 6.3.15 6.3.13 6.3.12 6.3.9; do \
-            curl -Ls --retry 5 --fail https://github.com/apple/foundationdb/releases/download/${old_fdb_server_version}/fdbserver.x86_64 -o ${OLD_FDB_BINARY_DIR}/fdbserver-${old_fdb_server_version}; \
-        done && \
-        chmod +x ${OLD_FDB_BINARY_DIR}/* && \
         curl -Ls --retry 5 --fail https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/libfdb_c.x86_64.so -o /usr/lib64/libfdb_c_${FDB_VERSION}.so && \
         ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so; \
     fi
-
-# Download swift binaries
-ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
-ARG SWIFT_PLATFORM=centos
-ARG OS_MAJOR_VER=7
-ARG SWIFT_WEBROOT=https://download.swift.org/development
-
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
-    OS_MAJOR_VER=$OS_MAJOR_VER \
-    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
-    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
-
-RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
-
-# Note: Swift package details may need further investigation for Rocky Linux 9
-# swift: error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory
-#RUN if [ "$(uname -p)" == "x86_64" ]; then \
-#        set -e; \
-#        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
-#        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  && \
-#        export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
-#        echo $DOWNLOAD_DIR > .swift_tag && \
-#        export GNUPGHOME="$(mktemp -d)" && \
-#        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
-#        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
-#        curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
-#        gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
-#        tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
-#        chmod -R o+r /usr/lib/swift && \
-#        rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz; \
-#    fi
-
-# Print Installed Swift Version
-# RUN if [ "$(uname -p)" == "x86_64" ]; then \
-#        swift --version; \
-#    fi
 
 ENV FDB_CLUSTER_FILE=/etc/foundationdb/fdb.cluster
 ENV AGENT_TIMEOUT=300
 
 USER joshua
-CMD python3.13 -m joshua.joshua_agent \
+CMD python3 -m joshua.joshua_agent \
         -C ${FDB_CLUSTER_FILE} \
         --work_dir /var/joshua \
         --agent-idle-timeout ${AGENT_TIMEOUT}

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -33,7 +33,6 @@ import threading
 import time
 import traceback
 import datetime
-from pprint import pprint
 
 # this is used to read / patch Pod labels
 from kubernetes import client, config

--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -20,6 +20,7 @@
 
 import argparse
 import errno
+import logging
 import os
 import queue
 import random
@@ -151,11 +152,8 @@ def trim_jobqueue(cutoff_date, remove_jobs=True):
 def log(outputText, newline=True):
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     message = f"[{timestamp}] {outputText}"
-    return (
-        print(message, file=getFileHandle())
-        if newline
-        else getFileHandle().write(message)
-    )
+    end = '\n' if newline else ''
+    print(message, file=getFileHandle(), end=end, flush=True)
 
 
 def agent_init(work_dir):
@@ -1151,6 +1149,9 @@ if __name__ == "__main__":
     else:
         agent_timeout = None
         log("No agent timeout configured - agent will run indefinitely")
+
+    # joshua_model uses logging
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s)] (%(levelname).3s) %(message)s")
 
     joshua_model.open(arguments.cluster_file, arguments.dir_path)
     agent_init(arguments.work_dir)

--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -97,9 +97,9 @@ def open(c_file=None, dir_path=("joshua",)):
     cluster_file = c_file
     db = fdb.open(cluster_file)
     # Timeout applies to all transactions. This should prevent FDB to hang forever.
-    transaction_timeout = int(os.environ.get("TRANSACTION_TIMEOUT_MS", "10000"))
+    transaction_timeout = int(os.environ.get("TRANSACTION_TIMEOUT_MS", "25000"))
     # Retry limit applies to all transactions. This should prevent FDB to hang forever.
-    transaction_retry_limit = int(os.environ.get("TRANSACTION_RETRY_LIMIT", "5"))
+    transaction_retry_limit = int(os.environ.get("TRANSACTION_RETRY_LIMIT", "25"))
     logger.info(f"transaction_timeout: {transaction_timeout} and transaction_retry_limit: {transaction_retry_limit}")
     db.options.set_transaction_timeout(transaction_timeout)
     db.options.set_transaction_retry_limit(transaction_retry_limit)

--- a/k8s/agent-scaler/Dockerfile
+++ b/k8s/agent-scaler/Dockerfile
@@ -1,24 +1,29 @@
-FROM rockylinux/rockylinux:9.6
+FROM rockylinux/rockylinux:9.7
 ARG AGENT_TAG=joshua-agent:latest
 
 # Currently Python 3.13 is used as the default python version 3.9 is EOL:
 # https://devguide.python.org/versions
+# gettext is for 'envsubst'
 RUN dnf -y update && \
     dnf install -y \
         epel-release \
         scl-utils \
         yum-utils && \
     dnf -y install \
-        gettext \
+        lsof \
         procps-ng \
+        gettext \
         jq-1.6 \
         python3.13 \
         python3.13-pip && \
-    ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
-    dnf -y clean all --enablerepo='*' && \
-    case $(uname -m) in \
-            x86_64) curl -Ls https://dl.k8s.io/release/v1.27.5/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl;; \
-            aarch64) curl -Ls https://dl.k8s.io/release/v1.27.5/bin/linux/arm64/kubectl -o /usr/local/bin/kubectl;; \
+    dnf -y clean all --enablerepo='*'
+
+RUN ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
+    ln -sf /usr/bin/pip3.13 /usr/bin/pip3
+
+RUN case $(uname -m) in \
+            x86_64) curl -Ls https://dl.k8s.io/release/v1.30.14/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl;; \
+            aarch64) curl -Ls https://dl.k8s.io/release/v1.30.14/bin/linux/arm64/kubectl -o /usr/local/bin/kubectl;; \
             *) echo "unsupported architecture for kubectl"; exit 1 ;; \
     esac; \
     chmod +x /usr/local/bin/kubectl
@@ -43,9 +48,9 @@ ENV LD_LIBRARY_PATH="/lib64:$LD_LIBRARY_PATH"
 
 # FDB python binding
 # TODO: This should be in a requirements file with version pinning.
-RUN python3.13 -m pip install \
+RUN python3 -m pip install \
         foundationdb==${FDB_VERSION} \
-        boto3
+        boto3==1.43.14
 
 ENV BATCH_SIZE=1
 ENV MAX_JOBS=10


### PR DESCRIPTION
joshua-agent should not need all these other language runtimes and old fdbserver binaries, it is expected to just run the job/ensemble tarball which contains shell script and mostly-static fdbserver to run simulation tests.

... I hope that's true, let me know if it isn't!