### PR TITLE
joshua-agent: re-include old fdbserver versions in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,15 +52,14 @@ RUN ARTIFACT=client python3 -m pip install /opt/joshua/install && \
     rm -rf /opt/joshua/install
 
 # install old fdbserver binaries and libfdb_c.so
-# Skip these old versions: 6.2.30 6.2.29 6.2.28 6.2.27 6.2.26 6.2.25 6.2.24 6.2.23 6.2.22 6.2.21 6.2.20 6.2.19 6.2.18 6.2.17 6.2.16 6.2.15 6.2.10 6.1.13 6.1.12 6.1.11 6.1.10 6.0.18 6.0.17 6.0.16 6.0.15 6.0.14 5.2.8 5.2.7 5.1.7 5.1.6
-# because 7.3 no longer supports upgrade from these versions.
+# just enough for foundationdb/tests/restarting/* for branches: release-7.3 release-7.4 main
 ARG OLD_FDB_BINARY_DIR=/app/deploy/global_data/oldBinaries/
 ARG FDB_VERSION="7.1.57"
 # This image only works for x86_64 ...
 RUN if [ "$(uname -p)" == "x86_64" ]; then \
         mkdir -p ${OLD_FDB_BINARY_DIR} \
                  /usr/lib/foundationdb/plugins && \
-        for old_fdb_server_version in 7.4.3 7.3.69 7.3.63 7.3.57 7.3.43 7.1.61 7.1.57 7.1.43 7.1.35 7.1.33 7.1.27 7.1.25 7.1.23 7.1.19 6.3.18 6.3.17 6.3.16 6.3.15 6.3.13 6.3.12 6.3.9; do \
+        for old_fdb_server_version in 7.4.5 7.3.69 7.3.43 7.1.61 7.1.57 7.1.19 6.3.18; do \
             curl -Ls --retry 5 --fail https://github.com/apple/foundationdb/releases/download/${old_fdb_server_version}/fdbserver.x86_64 -o ${OLD_FDB_BINARY_DIR}/fdbserver-${old_fdb_server_version}; \
         done && \
         chmod +x ${OLD_FDB_BINARY_DIR}/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ARG FDB_VERSION="7.1.57"
 RUN if [ "$(uname -p)" == "x86_64" ]; then \
         mkdir -p ${OLD_FDB_BINARY_DIR} \
                  /usr/lib/foundationdb/plugins && \
-        for old_fdb_server_version in 7.4.5 7.3.69 7.3.43 7.1.61 7.1.57 7.1.19 6.3.18; do \
+        for old_fdb_server_version in 7.4.5 7.3.69 7.3.43 7.1.61 7.1.19 6.3.18; do \
             curl -Ls --retry 5 --fail https://github.com/apple/foundationdb/releases/download/${old_fdb_server_version}/fdbserver.x86_64 -o ${OLD_FDB_BINARY_DIR}/fdbserver-${old_fdb_server_version}; \
         done && \
         chmod +x ${OLD_FDB_BINARY_DIR}/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,19 @@ COPY setup.py /opt/joshua/install/
 RUN ARTIFACT=client python3 -m pip install /opt/joshua/install && \
     rm -rf /opt/joshua/install
 
+# install old fdbserver binaries and libfdb_c.so
+# Skip these old versions: 6.2.30 6.2.29 6.2.28 6.2.27 6.2.26 6.2.25 6.2.24 6.2.23 6.2.22 6.2.21 6.2.20 6.2.19 6.2.18 6.2.17 6.2.16 6.2.15 6.2.10 6.1.13 6.1.12 6.1.11 6.1.10 6.0.18 6.0.17 6.0.16 6.0.15 6.0.14 5.2.8 5.2.7 5.1.7 5.1.6
+# because 7.3 no longer supports upgrade from these versions.
+ARG OLD_FDB_BINARY_DIR=/app/deploy/global_data/oldBinaries/
 ARG FDB_VERSION="7.1.57"
 # This image only works for x86_64 ...
 RUN if [ "$(uname -p)" == "x86_64" ]; then \
+        mkdir -p ${OLD_FDB_BINARY_DIR} \
+                 /usr/lib/foundationdb/plugins && \
+        for old_fdb_server_version in 7.4.3 7.3.69 7.3.63 7.3.57 7.3.43 7.1.61 7.1.57 7.1.43 7.1.35 7.1.33 7.1.27 7.1.25 7.1.23 7.1.19 6.3.18 6.3.17 6.3.16 6.3.15 6.3.13 6.3.12 6.3.9; do \
+            curl -Ls --retry 5 --fail https://github.com/apple/foundationdb/releases/download/${old_fdb_server_version}/fdbserver.x86_64 -o ${OLD_FDB_BINARY_DIR}/fdbserver-${old_fdb_server_version}; \
+        done && \
+        chmod +x ${OLD_FDB_BINARY_DIR}/* && \
         curl -Ls --retry 5 --fail https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/libfdb_c.x86_64.so -o /usr/lib64/libfdb_c_${FDB_VERSION}.so && \
         ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so; \
     fi


### PR DESCRIPTION
needed for restarting (upgrading) simulation tests

-------

I removed this in https://github.com/FoundationDB/fdb-joshua/pull/139 but now understand why they are needed, sorry!