### PR TITLE
setup: install only "client" module by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py313
+python_tag = py313

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,14 @@ if "ARTIFACT" in os.environ:
     elif os.environ["ARTIFACT"] == "server":
         modules = [all_modules[1]]
     elif os.environ["ARTIFACT"] == "all":
+        # Does not work for modern python3/pip:
+        # > AssertionError: Exactly one .egg-info should have been produced, but found 2
         modules = all_modules
     else:
         raise ValueError(f"Unknown artifact: {os.environ['ARTIFACT']}")
 else:
-    modules = all_modules
+    # default to client (modern python3/pip only allow one)
+    modules = all_modules[0]
 
 for module in modules:
     setup(


### PR DESCRIPTION
recent versions of python / setuptools do not allow multiple modules, resulting in:

> AssertionError: Exactly one .egg-info should have been produced,
> but found 2: ['joshua.egg-info', 'joshua_client.egg-info']

Also fix:

> SetuptoolsDeprecationWarning: Invalid dash-separated key 'python-tag'
> in 'bdist_wheel' (setup.cfg), please use the underscore name 'python_tag' instead.