### PR TITLE
Add cleanup for 'missed' completed jobs

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -292,6 +292,24 @@ def list_active_ensembles(tr) -> list[tuple[str, dict]]:
     return _list_ensembles(tr, dir_active)
 
 
+def stop_completed_ensembles():
+    """Stop any active ensembles where ended >= max_runs.
+
+    This is a sweep to catch ensembles that weren't stopped by
+    _insert_results due to the snapshot read race: when many agents
+    finish concurrently, all read a stale ended count and none triggers
+    _stop_ensemble.
+    """
+    stopped = []
+    for ensemble_id, props in list_active_ensembles():
+        max_runs = int(props.get("max_runs", 0))
+        ended = int(props.get("ended", 0))
+        if max_runs > 0 and ended >= max_runs:
+            stop_ensemble(ensemble_id)
+            stopped.append(ensemble_id)
+    return stopped
+
+
 @transactional
 def list_sanity_ensembles(tr) -> list[tuple[str, dict]]:
     return _list_ensembles(tr, dir_sanity)

--- a/k8s/agent-scaler/agent-scaler.sh
+++ b/k8s/agent-scaler/agent-scaler.sh
@@ -148,9 +148,8 @@ while true; do
 
     # Stop any ensembles that reached max_runs but weren't stopped due to
     # the snapshot read race in _insert_results.
-    python3 /tools/stop_completed_ensembles.py -C "${FDB_CLUSTER_FILE}" 2>&1 | while read -r line; do
-        echo "$(date -Iseconds) ${line}"
-    done
+    echo "$(date -Iseconds) Checking for stale completed ensembles ..."
+    python3 /tools/stop_completed_ensembles.py -C "${FDB_CLUSTER_FILE}"
 
     # Get the current ensembles
     # Pass the cluster file to the ensemble_count.py script

--- a/k8s/agent-scaler/agent-scaler.sh
+++ b/k8s/agent-scaler/agent-scaler.sh
@@ -146,6 +146,12 @@ while true; do
     # Clean up temp file
     rm -f /tmp/protected_failed_jobs_${AGENT_NAME}.txt
 
+    # Stop any ensembles that reached max_runs but weren't stopped due to
+    # the snapshot read race in _insert_results.
+    python3 /tools/stop_completed_ensembles.py -C "${FDB_CLUSTER_FILE}" 2>&1 | while read -r line; do
+        echo "$(date -Iseconds) ${line}"
+    done
+
     # Get the current ensembles
     # Pass the cluster file to the ensemble_count.py script
     if [ ! -f "${FDB_CLUSTER_FILE}" ]; then

--- a/k8s/agent-scaler/stop_completed_ensembles.py
+++ b/k8s/agent-scaler/stop_completed_ensembles.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+    stop_completed_ensembles.py - Stop ensembles that have reached max_runs.
+
+    Catches the race condition where concurrent agents all read a stale
+    'ended' count via snapshot reads and none triggers _stop_ensemble.
+"""
+
+import os
+import sys
+import argparse
+import joshua_model
+
+
+if __name__ == "__main__":
+    name_space = os.environ.get("JOSHUA_NAMESPACE", "joshua")
+    parser = argparse.ArgumentParser(description="Stop completed ensembles")
+    parser.add_argument(
+        "-C",
+        "--cluster-file",
+        "--cluster_file",
+        dest="cluster_file",
+        help="Cluster file for Joshua database",
+    )
+    parser.add_argument(
+        "-D",
+        "--dir-path",
+        nargs="+",
+        default=(name_space,),
+        help="top-level directory path in which joshua operates",
+    )
+
+    arguments = parser.parse_args()
+    joshua_model.open(arguments.cluster_file, arguments.dir_path)
+    stopped = joshua_model.stop_completed_ensembles()
+    for ensemble_id in stopped:
+        print(f"Stopped completed ensemble: {ensemble_id}", file=sys.stderr)


### PR DESCRIPTION
In _insert_results, the ended counter is incremented via atomic tr.add() but read via tr.snapshot.get(). When many agents finish concurrently, all see a stale pre-increment value — none sees ended >= max_runs, so nobody calls _stop_ensemble. The ensemble stays in the active list forever.

Add a periodic sweep in the agent-scaler loop that calls stop_completed_ensembles() — checks all active ensembles and stops any where ended >= max_runs. Three files changed:

 - joshua/joshua_model.py — added stop_completed_ensembles() function
 - k8s/agent-scaler/stop_completed_ensembles.py — CLI wrapper
 - k8s/agent-scaler/agent-scaler.sh — calls the sweep each loop iteration

The sweep runs every scaler cycle (typically every 30-60s). Minimal cost — just reads the active ensemble list and checks counters.