### PR TITLE
timeout for subprocess communicate() after SIGKILL

### DIFF
--- a/joshua/joshua_agent.py
+++ b/joshua/joshua_agent.py
@@ -605,7 +605,11 @@ class AsyncEnsemble:
                         # Still running after SIGTERM - force kill with SIGKILL
                         log("Process didn't terminate after SIGTERM - sending SIGKILL")
                         process.kill()
-                        remaining_out, remaining_err = process.communicate()
+                        try:
+                            remaining_out, remaining_err = process.communicate(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            log("Process didn't terminate after SIGKILL ?!")
+                            remaining_out = ""
 
                     # Combine partial output from timeout exception + remaining after terminate/kill
                     output = (timeout_ex.stdout or b"") + (remaining_out or b"")


### PR DESCRIPTION
Sometimes subprocess times-out, the agent sends SIGTERM, uses communicate() with 5 second timeout, then sends SIGKILL, and uses communicate() again. In test_delete_ensemble it was observed to occasionally hang here indefinitely after SIGKILL, so time-out this final communicate() also.