### PR TITLE
add xz back to Dockerfile for joshua_logtool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf update -y && \
         dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
     dnf install -y \
+        xz \
         lsof \
         net-tools \
         procps-ng \


### PR DESCRIPTION
This was removed in FoundationDB/fdb-joshua#139 c9cac79b9e14

foundationdb includes a contrib/joshua_logtool.py enabled by some test-harness options like TH_ENABLE_JOSHUA_LOGTOOL, and it compresses log tarballs with xz, on the joshua-agent.