### PR TITLE
Re-add valgrind to joshua-agent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN dnf update -y && \
         python3.13-devel \
         python3.13-pip \
         libffi-devel \
-        gcc && \
+        gcc \
+        valgrind && \
     dnf -y clean all --enablerepo='*'
 
 RUN ln -sf /usr/bin/python3.13 /usr/bin/python3 && \


### PR DESCRIPTION
c9cac79 ("slim joshua-agent Dockerfile / image") removed the valgrind package while slimming the agent. But the nightly valgrind ensemble (foundationdb-nightly-valgrind) runs `valgrind fdbserver -r simulation` on the agent, so agents without valgrind cannot run it: the ensemble gets zero results and run_joshua.py fails with "No progress for 3600s".