### PR TITLE
adjust test-requirements.txt for python-3.9 compat

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 foundationdb==7.1.57
-iniconfig==2.3.0
+iniconfig==2.1.0
 lxml==5.4.0
 packaging==26.2
 pluggy==1.6.0
@@ -7,6 +7,6 @@ psutil==5.9.2
 pytest==8.4.2
 python-dateutil==2.9.0.post0
 six==1.17.0
-boto3==1.43.14
+boto3==1.42.97
 kubernetes==30.1.0
 moto[s3]==4.2.14


### PR DESCRIPTION
just need to slightly downgrade iniconfig and boto3 for compatibility with python-3.9 which is what we have in our rockylinux9 base/build images
(for convenience of running fdb-joshua tests in our fdb dev containers)