### PR TITLE
joshua list: ensure space between ensemble ID and details

### DIFF
--- a/joshua/joshua.py
+++ b/joshua/joshua.py
@@ -45,7 +45,7 @@ def str_esc(v):
 
 
 def format_ensemble(e, props):
-    return f"  {e:50}" + " ".join(f"{k}={str_esc(v)}" for k, v in sorted(props.items()))
+    return f"  {e:50} " + " ".join(f"{k}={str_esc(v)}" for k, v in sorted(props.items()))
 
 
 def timestamp_of(time_string):


### PR DESCRIPTION
bug introduced in 161c46c23f07 / #145
(and didn't cause problems for manual joshua runs, but in CI with ensemble ID that hits max length, space was missing)