### PR TITLE
increase default fdb transaction timeout to 45 seconds

### DIFF
--- a/joshua/joshua_model.py
+++ b/joshua/joshua_model.py
@@ -94,7 +94,7 @@ def open(c_file=None, dir_path=("joshua",)):
     cluster_file = c_file
     db = fdb.open(cluster_file)
     # Timeout applies to all transactions. This should prevent FDB to hang forever.
-    transaction_timeout = int(os.environ.get("TRANSACTION_TIMEOUT_MS", "25000"))
+    transaction_timeout = int(os.environ.get("TRANSACTION_TIMEOUT_MS", "45000"))
     # Retry limit applies to all transactions. This should prevent FDB to hang forever.
     transaction_retry_limit = int(os.environ.get("TRANSACTION_RETRY_LIMIT", "25"))
     logger.info(f"transaction_timeout: {transaction_timeout} and transaction_retry_limit: {transaction_retry_limit}")


### PR DESCRIPTION
In a busy joshua cluster, transaction retries and timeouts can get pretty bad (joshua seems like not a good use case for fdb)